### PR TITLE
Adding run3 dataset and existing skim names

### DIFF
--- a/StandardAnalysis/python/IntegratedLuminosity_cff.py
+++ b/StandardAnalysis/python/IntegratedLuminosity_cff.py
@@ -390,10 +390,10 @@ lumi_2022_promptReco = {
     "MET_2022D" : 2.747864685317,
 
 # using HLT_IsoMu24_v* with Muon json files
-    "SingleMuon_2022A" : -1,
-    "SingleMuon_2022B" : 0.088919022, # 0.077329631 from golden json
-    "SingleMuon_2022C" : 5.726153735, # but I get 4.476362177when using the Golden json
-    "SingleMuon_2022D" : 3.271312170, # 2.747864685 from golden json
+    "SingleMu_2022A" : -1,
+    "SingleMu_2022B" : 0.077329631,
+    "SingleMu_2022C" : 4.476362177, 
+    "SingleMu_2022D" : 2.747864685, 
 
 # using HLT_Ele32_WPTight_Gsf_v*
     "SingleElectron_2022A:" : -1,
@@ -401,10 +401,6 @@ lumi_2022_promptReco = {
     "SingleElectron_2022C" : 4.476362177,
     "SingleElectron_2022D" : 2.747864685,
 
-
-    "SingleMu_2022A" : 1, #FIXME
-    "SingleMu_2022B" : 1, #FIXME
-    "SingleMu_2022C" : 1, #FIXME
 }
 
 # now create a single lumi dict, starting with 2015

--- a/StandardAnalysis/python/miniAOD_124X_Samples.py
+++ b/StandardAnalysis/python/miniAOD_124X_Samples.py
@@ -10,17 +10,42 @@ dataset_names_data = {
     'MET_2022A' : '/MET/Run2022A-PromptReco-v1/MINIAOD',
     'MET_2022B' : '/MET/Run2022B-PromptReco-v1/MINIAOD',
     'MET_2022C' : '/MET/Run2022C-PromptReco-v1/MINIAOD',
+    #'MET_2022D' : '/MET/Run2022D-PromptReco-v1/MINIAOD',
+    #'MET_2022E' : '/MET/Run2022E-PromptReco-v1/MINIAOD',
 
     #SingleMuon
     'SingleMu_2022A' : '/SingleMuon/Run2022A-PromptReco-v1/MINIAOD',
     'SingleMu_2022B' : '/SingleMuon/Run2022B-PromptReco-v1/MINIAOD',
     'SingleMu_2022C' : '/SingleMuon/Run2022C-PromptReco-v1/MINIAOD',
 
+    #EGamma
+    'EGamma_2022A' : '/EGamma/Run2022A-PromptReco-v1/MINIAOD',
+    'EGamma_2022B' : '/EGamma/Run2022B-PromptReco-v1/MINIAOD',
+    'EGamma_2022C' : '/EGamma/Run2022C-PromptReco-v1/MINIAOD',
+    'EGamma_2022D' : '/EGamma/Run2022D-PromptReco-v3/MINIAOD',
+    'EGamma_2022E' : '/EGamma/Run2022E-PromptReco-v1/MINIAOD',
+    'EGamma_2022F' : '/EGamma/Run2022F-PromptReco-v1/MINIAOD',
+
+    #Tau
+    'Tau_2022A' : '/Tau/Run2022A-PromptReco-v1/MINIAOD',
+    'Tau_2022B' : '/Tau/Run2022B-PromptReco-v1/MINIAOD',
+    'Tau_2022C' : '/Tau/Run2022C-PromptReco-v1/MINIAOD',
+    'Tau_2022D' : '/Tau/Run2022D-PromptReco-v3/MINIAOD',
+    'Tau_2022E' : '/Tau/Run2022E-PromptReco-v1/MINIAOD',
+    'Tau_2022F' : '/Tau/Run2022F-PromptReco-v1/MINIAOD',
+
+
 }
-run3_skim_sibling_datasets = { # Fixme
-    'MET_2022A' : '/MET/Run2022A-EXOHighMET-PromptReco-v1/RAW-RECO',
-    'MET_2022B' : '/MET/Run2022B-EXOHighMET-PromptReco-v1/RAW-RECO',
-    'MET_2022C' : '/MET/Run2022C-EXOHighMET-PromptReco-v1/RAW-RECO',
+run3_skim_sibling_datasets = { # Fixme -> added those that exist as of Nov 14, 2022
+
+    #EGamma
+    'EGamma_2022E' : '/EGamma/Run2022E-EXODisappTrk-PromptReco-v1/AOD',
+    'EGamma_2022F' : '/EGamma/Run2022F-EXODisappTrk-PromptReco-v1/AOD',
+
+    #Tau
+    'Tau_2022E' : '/Tau/Run2022E-EXODisappTrk-PromptReco-v1/AOD',
+    'Tau_2022F' : '/Tau/Run2022F-EXODisappTrk-PromptReco-v1/AOD',
+
 }
 
 dataset_names_sig = {}


### PR DESCRIPTION
Added the datasets and currenctly existing AOD skims to miniAOD_124X_Samples.py.  Also updated luminosity numbers for 2022 in IntegratedLuminosity_cff.py.