### PR TITLE
Modifying proto and localConfig for Run3 signal MC

### DIFF
--- a/StandardAnalysis/python/localConfig.py
+++ b/StandardAnalysis/python/localConfig.py
@@ -68,10 +68,11 @@ datasetsBkgd = [
     'VV',
     'SingleTop',
 ]
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
-    datasetsBkgd.append('TTJetsComposite')
-else:
-    datasetsBkgd.append('TTJets')
+#TODO: need to check what this does and if it is useful or not for run3 CMSSW_12_4_
+#if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
+#    datasetsBkgd.append('TTJetsComposite')
+#else:
+#    datasetsBkgd.append('TTJets')
 
 datasetsBkgdForMET = copy.deepcopy(datasetsBkgd)
 

--- a/StandardAnalysis/python/localConfig.py
+++ b/StandardAnalysis/python/localConfig.py
@@ -133,6 +133,8 @@ datasetsSig = [
     'AMSB_chargino_1100GeV_100cm_76X',
     'AMSB_chargino_1100GeV_1000cm_76X',
     'AMSB_chargino_1100GeV_10000cm_76X',
+
+    'AMSB_chargino_700GeV_100cm_124X',
 ]
 
 datasetsSigHiggsino = []
@@ -207,12 +209,13 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
         datasetsSig.append('AMSB_chargino_' + str(i) + 'GeV_1cm_102X')
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_"):
     print("# Signal samples: " + A_BRIGHT_CYAN + "124X samples" + A_RESET)
-    for i in range(0, len(datasetsSig)):
-        datasetsSig[i] = re.sub (r"(.*)_76X$", r"\1_102X", datasetsSig[i])
-    for i in range (0, len (datasetsSigHiggsino)):
-        datasetsSigHiggsino[i] = re.sub (r"(.*)_76X$", r"\1_102X", datasetsSigHiggsino[i])
-    for i in [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100]:
-        datasetsSig.append('AMSB_chargino_' + str(i) + 'GeV_1cm_102X')
+    #TODO: update this to use the existing MC signal samples when everything works!!!
+    #for i in range(0, len(datasetsSig)):
+    #    datasetsSig[i] = re.sub (r"(.*)_76X$", r"\1_102X", datasetsSig[i])
+    #for i in range (0, len (datasetsSigHiggsino)):
+    #    datasetsSigHiggsino[i] = re.sub (r"(.*)_76X$", r"\1_102X", datasetsSigHiggsino[i])
+    #for i in [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100]:
+    #    datasetsSig.append('AMSB_chargino_' + str(i) + 'GeV_1cm_102X')
 else:
     print("# Signal samples: " + A_BRIGHT_CYAN + "76X samples" + A_RESET)
 
@@ -242,8 +245,9 @@ datasetsSigHiggsinoShort700 = [x for x in datasetsSigHiggsino if x.startswith('H
 datasetsSigHiggsinoShort800 = [x for x in datasetsSigHiggsino if x.startswith('Higgsino_800GeV_')]
 datasetsSigHiggsinoShort900 = [x for x in datasetsSigHiggsino if x.startswith('Higgsino_900GeV_')]
 
-addLifetimeReweighting (datasetsSig)
-addLifetimeReweighting (datasetsSigHiggsino, isHiggsino = True)
+#TODO: update this to use the existing MC signal samples when everything works!!!
+#addLifetimeReweighting (datasetsSig)
+#addLifetimeReweighting (datasetsSigHiggsino, isHiggsino = True)
 
 higgsino_xsecs = { # [pb]
     '100' : 13.53557,

--- a/StandardAnalysis/python/protoConfig_cfg.py
+++ b/StandardAnalysis/python/protoConfig_cfg.py
@@ -19,7 +19,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     mc_global_tag = '102X_upgrade2018_realistic_v18'
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_"):
     data_global_tag = '124X_dataRun3_Prompt_v4'
-    mc_global_tag = 'fixme'
+    mc_global_tag = '124X_mcRun3_2022_realistic_v12'
 ################################################################################
 # Create the skeleton process
 ################################################################################
@@ -186,6 +186,9 @@ else:
         print("# Collections: collectionMap with candidateTrackProducer")
         collMap.tracks = cms.InputTag ('candidateTrackProducer')
         collMap.secondaryTracks = cms.InputTag ('candidateTrackProducer')
+
+print(collMap.tracks)
+print(collMap.secondaryTracks)
 
 if UseGeantDecays:
     print("# hardInteractionMcparticles: prunedGenParticlePlusGeant")


### PR DESCRIPTION
Changing GlobalTag in `StandardAnalysis/python/protoConfig_cfg.py` for Run3 2022 and commenting some lines from `StandardAnalysis/python/localConfig.py` to facilitate the usage during tests -> needs to be updated as soon as all signal MC samples are ready.