### PR TITLE
Update data paths and switch order of AOD/MINIAOD

### DIFF
--- a/StandardAnalysis/python/miniAOD_124X_Samples.py
+++ b/StandardAnalysis/python/miniAOD_124X_Samples.py
@@ -1,30 +1,104 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ############################################################################################################
 #########  LIST OF MINIAOD 2022 12_4_X DATASETS  ###########################################################
 ###########################################################################################################
 
 
-dataset_names_data = {
-
-    'MET_2022A' : '/MET/Run2022A-PromptReco-v1/MINIAOD',
-    'MET_2022B' : '/MET/Run2022B-PromptReco-v1/MINIAOD',
-    'MET_2022C' : '/MET/Run2022C-PromptReco-v1/MINIAOD',
-
+run3_skim_sibling_datasets = {
+    # EGamma
+    "EGamma_2022C": "/EGamma/Run2022C-EXODisappTrk-27Jun2023-v1/AOD",
+    "EGamma_2022D": "/EGamma/Run2022D-EXODisappTrk-27Jun2023-v2/AOD",
+    "EGamma_2022E": "/EGamma/Run2022E-EXODisappTrk-27Jun2023-v1/AOD",
+    "EGamma_2022F": "/EGamma/Run2022F-EXODisappTrk-PromptReco-v1/AOD",
+    "EGamma_2022G": "/EGamma/Run2022G-EXODisappTrk-PromptReco-v1/AOD",
+    # Tau
+    "Tau_2022C": "/Tau/Run2022C-EXODisappTrk-27Jun2023-v2/AOD",
+    "Tau_2022D": "/Tau/Run2022D-EXODisappTrk-27Jun2023-v2/AOD",
+    "Tau_2022E": "/Tau/Run2022E-EXODisappTrk-27Jun2023-v1/AOD",
+    "Tau_2022F": "/Tau/Run2022F-EXODisappTrk-PromptReco-v1/AOD",
+    "Tau_2022G": "/Tau/Run2022G-EXODisappTrk-PromptReco-v1/AOD",
+    # MET
+    #'MET_2022A' : '/MET/lpclonglived-Skim_EXODisappTrks_MET_Run2022A-485942db884bb77e20d203394ccaa614/USER',
+    #'MET_2022B' : '/MET/lpclonglived-Skim_EXODisappTrks_MET_Run2022B-485942db884bb77e20d203394ccaa614/USER',
+    #'MET_2022C' : '/MET/lpclonglived-Skim_EXODisappTrks_MET_Run2022C-485942db884bb77e20d203394ccaa614/USER',
+    #'MET_2022D' : '',
+    #'MET_2022E' : '/JetMET/Run2022E-EXODisappTrk-PromptReco-v1/AOD',
+    #'MET_2022F' : '/JetMET/Run2022F-EXODisappTrk-PromptReco-v1/AOD',
+    #'MET_2022G' : '/JetMET/Run2022G-EXODisappTrk-PromptReco-v1/AOD',
+    # temporary
+    "MET_2022A": "/MET/Run2022A-27Jun2023-v1/AOD",
+    "MET_2022B": "/MET/Run2022B-16Jun2023-v2/AOD",
+    "MET_2022C": "/MET/Run2022C-27Jun2023-v2/AOD",
+    "MET_2022D": "/JetMET/Run2022D-EXODisappTrk-27Jun2023-v2/AOD",
+    "MET_2022E": "/JetMET/Run2022E-EXODisappTrk-27Jun2023-v1/AOD",
+    "MET_2022F": "/JetMET/Run2022F-EXODisappTrk-PromptReco-v1/AOD",
+    "MET_2022G": "/JetMET/Run2022G-EXODisappTrk-PromptReco-v1/AOD",
+    # Muon
+    "SingleMu_2022C": "/Muon/Run2022C-EXODisappTrk-27Jun2023-v1/AOD",
+    "SingleMu_2022D": "/Muon/Run2022D-EXODisappTrk-27Jun2023-v2/AOD",
+    "SingleMu_2022E": "/Muon/Run2022E-EXODisappTrk-27Jun2023-v1/AOD",
+    "SingleMu_2022F": "/Muon/Run2022F-EXODisappTrk-PromptReco-v1/AOD",
+    "SingleMu_2022G": "/Muon/Run2022G-EXODisappTrk-PromptReco-v1/AOD",
 }
 
-dataset_names_sig = {}
+dataset_names_data = {  # Fixme -> added those that exist as of Nov 14, 2022
+    # MET
+    #'MET_2022A' : '/MET/Run2022A-PromptReco-v1/MINIAOD',
+    #'MET_2022B' : '/MET/Run2022B-PromptReco-v1/MINIAOD',
+    #'MET_2022C' : '/MET/Run2022C-PromptReco-v1/MINIAOD',
+    #'MET_2022D' : '/JetMET/Run2022D-10Dec2022-v1/MINIAOD',
+    #'MET_2022E' : '/JetMET/Run2022E-PromptReco-v1/MINIAOD',
+    #'MET_2022F' : '/JetMET/Run2022F-PromptReco-v1/MINIAOD',
+    #'MET_2022G' : '/JetMET/Run2022G-PromptReco-v1/MINIAOD',
+    # SingleMuon
+    "SingleMu_2022A": "/SingleMuon/Run2022A-PromptReco-v1/MINIAOD",
+    "SingleMu_2022B": "/SingleMuon/Run2022B-PromptReco-v1/MINIAOD",
+    "SingleMu_2022C": "/Muon/Run2022C-22Sep2023-v1/MINIAOD",
+    "SingleMu_2022D": "/Muon/Run2022D-22Sep2023-v1/MINIAOD",
+    "SingleMu_2022E": "/Muon/Run2022E-22Sep2023-v1/MINIAOD",
+    "SingleMu_2022F": "/Muon/Run2022F-PromptReco-v1/MINIAOD",
+    "SingleMu_2022G": "/Muon/Run2022G-22Sep2023-v1/MINIAOD",
+    # EGamma
+    "EGamma_2022A": "/EGamma/Run2022A-22Sep2023-v1/MINIAOD",
+    "EGamma_2022B": "/EGamma/Run2022B-22Sep2023-v2/MINIAOD",
+    "EGamma_2022C": "/EGamma/Run2022C-22Sep2023-v1/MINIAOD",
+    "EGamma_2022D": "/EGamma/Run2022D-22Sep2023-v1/MINIAOD",
+    "EGamma_2022E": "/EGamma/Run2022E-22Sep2023-v1/MINIAOD",
+    "EGamma_2022F": "/EGamma/Run2022F-22Sep2023-v1/MINIAOD",
+    "EGamma_2022G": "/EGamma/Run2022G-PromptReco-v1/MINIAOD",
+    # Tau
+    "Tau_2022C": "/Tau/Run2022C-22Sep2023-v1/MINIAOD",
+    "Tau_2022D": "/Tau/Run2022D-22Sep2023-v1/MINIAOD",
+    "Tau_2022E": "/Tau/Run2022E-22Sep2023-v1/MINIAOD",
+    "Tau_2022F": "/Tau/Run2022F-22Sep2023-v1/MINIAOD",
+    "Tau_2022G": "/Tau/Run2022G-22Sep2023-v1/MINIAOD",
+
+    "MET_2022A": "/MET/Run2022A-22Sep2023-v1/MINIAOD",
+    "MET_2022B": "/MET/Run2022B-22Sep2023-v1/MINIAOD",
+    "MET_2022C": "/MET/Run2022C-22Sep2023-v1/MINIAOD",
+    "MET_2022D": "/JetMET/Run2022D-22Sep2023-v1/MINIAOD",
+    "MET_2022E": "/JetMET/Run2022E-22Sep2023-v1/MINIAOD",
+    "MET_2022F": "/JetMET/Run2022F-PromptReco-v1/MINIAOD",
+    "MET_2022G": "/JetMET/Run2022G-22Sep2023-v2/MINIAOD",
+
+    "AMSB_chargino_700GeV_100cm_124X": "/AMSB_chargino_M-700GeV_CTau-100cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/borzari-Run3Summer22DRPremixMiniAOD-124X_mcRun3_2022_realistic_v12-v1_step3/USER",
+}
+
+dataset_names_sig = {
+    "AMSB_chargino_700GeV_100cm_124X": "/AMSB_chargino_M-700GeV_CTau-100cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/borzari-Run3Summer22DRPremixMiniAOD-124X_mcRun3_2022_realistic_v12-v1_step4/USER",
+}
 
 dataset_names_bkgd = {}
 
 dataset_names = {}
-dataset_names.update (dataset_names_data)
-dataset_names.update (dataset_names_bkgd)
-dataset_names.update (dataset_names_sig)
+dataset_names.update(dataset_names_data)
+dataset_names.update(dataset_names_bkgd)
+dataset_names.update(dataset_names_sig)
 
 import re
 
-'''
+"""
 new_dataset_names = {}
 for dataset0 in dataset_names:
     if not re.match (r'AMSB_chargino_[^_]*GeV_[^_]*cm_.*', dataset0):
@@ -45,4 +119,4 @@ for dataset0 in dataset_names:
 
 dataset_names.update (new_dataset_names)
                                                                                                                                                                                                  180,1         Bot
-'''
+"""


### PR DESCRIPTION
The data paths should be updated in miniAOD_124X_Samples.py and the order of AOD and miniAOD should be switched now