### PR TITLE
Jet Veto Map

### DIFF
--- a/StandardAnalysis/plugins/EventJetVarProducer.cc
+++ b/StandardAnalysis/plugins/EventJetVarProducer.cc
@@ -40,6 +40,7 @@ private:
   edm::EDGetTokenT<vector<pat::PackedCandidate> >   tokenLostTracks_;
   edm::EDGetTokenT<vector<TYPE(hardInteractionMcparticles)> > tokenMcparticles_;
   edm::EDGetTokenT<edm::TriggerResults>             tokenTriggerBits_;
+  edm::EDGetTokenT<vector<TYPE(muons)> >            tokenMuons_;
 
   double genGluinoMass_, genNeutralinoMass_, genCharginoMass_;
 
@@ -54,6 +55,8 @@ private:
   bool hasNeutralino (const edm::Handle<vector<TYPE(hardInteractionMcparticles)> > &) const;
   void findGenMasses (const edm::Handle<vector<TYPE(hardInteractionMcparticles)> > &);
   uint32_t packTriggerFires (const edm::Event &event, const edm::Handle<edm::TriggerResults> &) const;
+  bool jetLooseSelection (const TYPE(jets)&, const vector<TYPE(muons)> &) const;
+  bool jetTightID (const TYPE(jets)&) const;
 
   vector<string> triggerNames;
   
@@ -69,6 +72,7 @@ EventJetVarProducer::EventJetVarProducer(const edm::ParameterSet &cfg) :
   tokenLostTracks_  =  consumes<vector<pat::PackedCandidate> >   (collections_.getParameter<edm::InputTag>  ("lostTracks"));
   tokenMcparticles_ =  consumes<vector<TYPE(hardInteractionMcparticles)> > (collections_.getParameter<edm::InputTag>  ("hardInteractionMcparticles"));
   tokenTriggerBits_ =  consumes<edm::TriggerResults>(collections_.getParameter<edm::InputTag>("triggers"));
+  tokenMuons_       =  consumes<vector<TYPE(muons)> >            (collections_.getParameter<edm::InputTag>  ("muons"));
 
   triggerNames = cfg.getParameter<vector<string> >("triggerNames");
 
@@ -116,6 +120,12 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
     return;
   }
 
+  edm::Handle<vector<TYPE(muons)> > muons;
+  if (!event.getByToken (tokenMuons_, muons)) {
+    clog << "ERROR:  Could not find muons collection." << endl;
+    return;
+  }
+
   edm::Handle<vector<pat::PackedCandidate> > lostTracks;
   event.getByToken (tokenLostTracks_, lostTracks);
 
@@ -124,6 +134,9 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
 
   edm::Handle<edm::TriggerResults> triggerBits;
   event.getByToken(tokenTriggerBits_, triggerBits);
+
+  TFile* f_jetVeto = TFile::Open("/data/users/mcarrigan/condor/run3Inputs/Summer22EE_23Sep2023_RunEFG_v1.root", "read");
+  TH2D* jetVetoMap = (TH2D*)f_jetVeto->Get("jetvetomap");
 
   vector<PhysicsObject> validJets;
   double dijetMaxDeltaPhi         = -999.;  // default is large negative value
@@ -204,7 +217,15 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
   bool jetIn_hem1516 = false;
   bool jetOpposite_hem1516 = false;
   bool metJet_hem1516 = false;
+
+  bool jetVeto2022 = false;
+
   for (const auto &jet1 : *jets) {
+    if (jetLooseSelection(jet1, *muons)) {
+      if (jetVetoMap->GetBinContent(jetVetoMap->FindFixBin(jet1.eta(), jet1.phi())) > 0){
+        jetVeto2022 = true;
+      } 
+    }
     if (jet1.eta() >= -3.0 && jet1.eta() <= -1.3) {
       if (jet1.phi() >= -1.57 && jet1.phi() <= -0.87) jetIn_hem1516 = true;
       if (jet1.phi() >= -1.57 + 3.14159 && jet1.phi() <= -0.87 + 3.14159) jetOpposite_hem1516 = true;
@@ -251,8 +272,11 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
   (*eventvariables)["jetInHEM1516"] = jetIn_hem1516;
   (*eventvariables)["jetOppositeHEM1516"] = jetOpposite_hem1516;
   (*eventvariables)["metJetHEM1516"] = metJet_hem1516;
+  (*eventvariables)["jetVeto2022"] = jetVeto2022;
 
   isFirstEvent_ = false;
+
+  f_jetVeto->Close();
 }
 
 unsigned
@@ -403,6 +427,72 @@ EventJetVarProducer::packTriggerFires (const edm::Event &event, const edm::Handl
   // if you never found a path you're interested in in allTriggerNames, then it's safe to say it didn't fire
   return value;
 }
+
+bool 
+EventJetVarProducer::jetLooseSelection (const TYPE(jets) &jet, const vector<TYPE(muons)> &muons) const
+{
+  // jet pt cut
+  if ( jet.pt() < 15 ) return false;
+  
+  // jet em fraction < 0.9
+  if ( jet.neutralEmEnergyFraction() < 0.9 ) return false;
+
+  // dR(jet, muon) > 0.2
+  for (auto& muon: muons){
+    double dR = deltaR(jet, muon);
+    if ( dR < 0.2 ) return false;
+  }
+
+  //Add JET tight ID
+  if (!jetTightID(jet)) return false;
+  
+  //Add Jet PU ID once suggestions are given by Jets Group https://twiki.cern.ch/twiki/bin/viewauth/CMS/PileupJetID
+  
+  return true;
+
+}
+
+//Jet Tight ID for 2022 as defined https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV
+bool 
+EventJetVarProducer::jetTightID (const TYPE(jets)& jet) const
+{
+
+  if ( fabs(jet.eta()) <= 2.6 ) {
+    if ( jet.neutralHadronEnergyFraction() >= 0.99 ) return false;
+    if ( jet.neutralEmEnergyFraction() >= 0.90 ) return false;
+    if ( (jet.chargedMultiplicity() + jet.neutralMultiplicity()) <= 1 ) return false;
+    if ( jet.muonEnergyFraction() >= 0.80 ) return false;
+    if ( jet.chargedHadronEnergyFraction() <= 0.01 ) return false;
+    if ( jet.chargedMultiplicity() <= 0 ) return false;
+    if ( jet.chargedEmEnergyFraction() >= 0.80 ) return false; 
+    return true;
+  }
+  else if ( (fabs(jet.eta()) > 2.6) && (fabs(jet.eta()) <= 2.7) ){
+    if ( jet.neutralHadronEnergyFraction() >= 0.90 ) return false;
+    if ( jet.neutralEmEnergyFraction() >= 0.99 ) return false;
+    if ( jet.muonEnergyFraction() >= 0.80 ) return false;
+    if ( jet.chargedMultiplicity() <= 0 ) return false;
+    if ( jet.chargedEmEnergyFraction() >= 0.80 ) return false; 
+    return true;
+  }
+  else if( (fabs(jet.eta()) > 2.7) && (fabs(jet.eta()) <= 3.0) ){
+    if ( jet.neutralHadronEnergyFraction() >= 0.99 ) return false;
+    if ( jet.neutralEmEnergyFraction() >= 0.99 ) return false;
+    if ( jet.neutralMultiplicity() <= 1 ) return false;
+    return true;
+  }
+  else if( (fabs(jet.eta()) > 3.0) && (fabs(jet.eta()) <= 5.0) ) {
+    if ( jet.neutralEmEnergyFraction() >= 0.40 ) return false;
+    if ( jet.neutralMultiplicity() <= 10 ) return false;
+    return true;
+  }
+  else{
+    return false;
+  }
+
+}
+
+
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(EventJetVarProducer);

--- a/StandardAnalysis/python/Cuts.py
+++ b/StandardAnalysis/python/Cuts.py
@@ -67,6 +67,12 @@ cutVetoJetsHEM1516 = cms.PSet(
     numberRequired = cms.string(">= 1"),
 )
 
+cutVetoJetMap2022 = cms.PSet(
+    inputCollection = cms.vstring("eventvariables"),
+    cutString = cms.string("jetVeto2022 == 0"),
+    numberRequired = cms.string(">= 1"),
+)
+
 cutDummyMet = cms.PSet(
     inputCollection = cms.vstring("mets"),
     cutString = cms.string("noMuPt > -1"),
@@ -312,12 +318,12 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_"):
     cutJetTightLepVeto.cutString = cms.string("\
     (\
-    (abs(eta) <= 2.6 && neutralHadronEnergyFraction<0.90 && neutralEmEnergyFraction<0.90 && (chargedMultiplicity + neutralMultiplicity)>1 && muonEnergyFraction<0.8 && chargedHadronEnergyFraction>0 && chargedMultiplicity>0 && chargedEmEnergyFraction<0.80) || \
+    (abs(eta) <= 2.6 && neutralHadronEnergyFraction<0.99 && neutralEmEnergyFraction<0.90 && (chargedMultiplicity + neutralMultiplicity)>1 && muonEnergyFraction<0.8 && chargedHadronEnergyFraction>0.01 && chargedMultiplicity>0 && chargedEmEnergyFraction<0.80) || \
     (abs(eta) > 2.6 && abs(eta) <= 2.7 && neutralHadronEnergyFraction<0.90 && neutralEmEnergyFraction<0.99 && muonEnergyFraction<0.8 && chargedMultiplicity>0 && chargedEmEnergyFraction<0.8) || \
-    (abs(eta) > 2.7 && abs(eta) <= 3.0 && neutralEmEnergyFraction>0.02 && neutralEmEnergyFraction<0.99 && neutralMultiplicity>2) || \
-    (abs(eta) > 3.0 && neutralEmEnergyFraction<0.90 && neutralHadronEnergyFraction>0.2 && neutralMultiplicity>10)\
+    (abs(eta) > 2.7 && abs(eta) <= 3.0 && neutralEmEnergyFraction<0.99 && neutralHadronEnergyFraction<0.99 && neutralMultiplicity>1) || \
+    (abs(eta) > 3.0 && neutralEmEnergyFraction<0.4 && neutralMultiplicity>10)\
     )")
-    print('# Using 2018 reqs for Jet TightLepVeto FIXME for 2022')
+    print('# Using 2022 reqs for Jet TightLepVeto https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV')
 
 #############
 # pair of jets pt > 30

--- a/StandardAnalysis/python/EventSelections.py
+++ b/StandardAnalysis/python/EventSelections.py
@@ -37,6 +37,11 @@ vertexCutOnly = cms.PSet(
     )
 )
 
+jetVetoMap2022 = copy.deepcopy (vertexCutOnly)
+jetVetoMap2022.name = cms.string ("jetVetoMap2022")
+jetVetoMapCut = [cutVetoJetMap2022]
+addCuts(jetVetoMap2022.cuts, jetVetoMapCut)
+
 metMinimalSkim = copy.deepcopy (vertexCutOnly)
 metMinimalSkim.name = cms.string ("metMinimalSkim")
 addCuts (metMinimalSkim.cuts, [cutMet])

--- a/StandardAnalysis/python/HistogramDefinitions.py
+++ b/StandardAnalysis/python/HistogramDefinitions.py
@@ -1194,8 +1194,8 @@ JetExtraHistograms = cms.PSet(
         cms.PSet (
             name = cms.string("jetEtaVsPhi"),
             title = cms.string("jetEtaVsPhi;jetEtaVsPhi"),
-            binsX = cms.untracked.vdouble(100, -3, 3),
-            binsY = cms.untracked.vdouble(100, -3, 3),
+            binsX = cms.untracked.vdouble(82, -5.191, 5.191),
+            binsY = cms.untracked.vdouble(72, -3.1415927, 3.1415927),
             inputVariables = cms.vstring("eta" , "phi"),
         ),
         cms.PSet (
@@ -2005,6 +2005,12 @@ EventVariableHistograms = cms.PSet(
             title = cms.string(";jet pointing away, met towards HEM 15/16"),
             binsX = cms.untracked.vdouble(2, -0.5, 1.5),
             inputVariables = cms.vstring("metJetHEM1516"),
+        ),
+        cms.PSet (
+            name = cms.string("vetoJetMap2022"),
+            title = cms.string("Jet in Veto Map 2022"),
+            binsX = cms.untracked.vdouble(2, -0.5, 1.5),
+            inputVariables = cms.vstring("jetVeto2022"),
         ),
     )
 )

--- a/StandardAnalysis/python/config_cfg.py
+++ b/StandardAnalysis/python/config_cfg.py
@@ -14,6 +14,7 @@ from DisappTrks.StandardAnalysis.protoConfig_cfg import *
 
 # Channels needed for background estimates and systematics
 #  add_channels  (process,  [vertexCutOnly],                 histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  [jetVetoMap2022],                 histSets,  weights,  [],  collMap,  variableProducers,  True, forceNonEmptySkim=True)
 #  add_channels  (process,  [basicSelectionNoAngularCuts],   histSets,  weights,  [],  collMap,  variableProducers,  False)
 #  add_channels  (process,  [basicSelectionNoDijetPhiCut],   histSets,  weights,  [],  collMap,  variableProducers,  False)
 #  add_channels  (process,  [basicSelectionNoJetMetPhiCut],  histSets,  weights,  [],  collMap,  variableProducers,  False)

--- a/StandardAnalysis/test/makeRatioPlots.py
+++ b/StandardAnalysis/test/makeRatioPlots.py
@@ -1,0 +1,93 @@
+import ROOT as r
+
+def makeComparrisonPlot(trees, plot):
+
+    histograms = []
+
+    for i in enumerate(trees):
+        h = r.TH1F()
+        histograms.append(h)
+
+    for ih, (key, value) in enumerate(trees.items()):
+        try:
+            histograms[ih] = value.Get(key+'/'+plot)
+        except:
+            print("Could not create histogram {}".format(plot))
+        
+    return histograms
+
+
+
+def plotTogether(trees, histos, plot, fout, pos=[0.6, 0.6, 0.8, 0.8]):
+    
+    c1 = r.TCanvas("c1", "c1", 600, 600)
+    c1.cd()
+    
+    names = list(trees.keys())
+    
+    l1=r.TLegend(pos[0], pos[1], pos[2], pos[3])
+
+    if len(histos) == 2:
+        if plot.GetClassName()=="TH1D":
+            histName = histos[0].GetTitle()
+            if histName == "": 
+                print("hist has no title", plot.GetName())
+                histName = plot.GetName()
+            histos[0].SetTitle(histName)
+            histos[1].SetLineColor(2)
+            ratio = r.TRatioPlot(histos[0], histos[1])
+            l1.AddEntry(histos[0], names[0], 'l')
+            l1.AddEntry(histos[1], names[1], 'l')
+            ratio.Draw()
+            ratio.GetUpperPad().cd()
+            l1.Draw()
+        elif plot.GetClassName()=="TH2D":
+            h1 = histos[0].Clone()
+            h1.Divide(histos[1])
+            h1.Draw("colz")
+            h1.SetTitle("{} \n Ratio {} / {}".format(plot.GetName(), names[0], names[1]))
+    else:
+        for ih, h in enumerate(histos):
+            if plot.GetClassName()=='TH1D':
+                if ih == 0: 
+                    h.Draw("hist")
+                    h.SetTitle(plot.GetName())
+                else: 
+                    h.SetLineColor(2)
+                    h.Draw("hist same")
+                l1.AddEntry(h, names[ih], 'l')
+                l1.Draw()
+
+            elif plot.GetClassName()=="TH2D":
+                print("TH2")
+            else:
+                print("Plot is not of type TH1D or TH2D, skipping...")
+    
+    fout.cd()
+    c1.Write(plot.GetName())
+    c1.Delete()
+    
+
+if __name__ == "__main__":
+
+    r.gROOT.SetBatch(1)
+
+    vertex = r.TFile.Open("condor/EGamma_2022/EGamma_2022F_vertexOnly/EGamma_2022F.root")
+    basic = r.TFile.Open("condor/EGamma_2022/EGamma_2022F_basicSelection/EGamma_2022F.root")
+
+    vertex.cd('VertexCutOnlyPlotter/Track Plots')
+    basic.cd('BasicSelectionPlotter/Track Plots')
+
+    trees = {"VertexCutOnlyPlotter": vertex, "BasicSelectionPlotter": basic}
+
+    fout = r.TFile.Open("combinedPlots.root", 'recreate')
+
+    for key in vertex.VertexCutOnlyPlotter.GetListOfKeys():
+        sub = key.ReadObj()
+        for ikey2, key2 in enumerate(sub.GetListOfKeys()):
+            print(key2.GetName())
+            pltName = key.GetName()+'/'+key2.GetName()
+            histos = makeComparrisonPlot(trees, pltName)
+            plotTogether(trees, histos, key2, fout)
+        
+    #fout.Close()


### PR DESCRIPTION
Adds "loose jet selection" to EventJetProducer and cut jetVetoMap2022 to veto any events with a jet passing loose selection and passing through the jet veto map from the JERC group.

Also updates the JetTightID definition for 2022

Added script StandardAnalysis/test/makeRatioPlots.py to compare different cut selections