### PR TITLE
Fix memory leak in EventJetVarProducer, fix fiducial maps in 2022

### DIFF
--- a/StandardAnalysis/plugins/EventJetVarProducer.cc
+++ b/StandardAnalysis/plugins/EventJetVarProducer.cc
@@ -143,6 +143,10 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
   TFile* f_jetVeto = TFile::Open(jetVetoName.c_str(), "read");
   TH2D* jetVetoMap = (TH2D*)f_jetVeto->Get("jetvetomap");
 
+  jetVetoMap->SetDirectory(0);
+  f_jetVeto->Close();
+  delete f_jetVeto;
+
   vector<PhysicsObject> validJets;
   double dijetMaxDeltaPhi         = -999.;  // default is large negative value
   double deltaPhiMetJetLeading    =  999.;  // default is large positive value
@@ -238,6 +242,8 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
     }
   }
 
+  delete jetVetoMap;
+
   findGenMasses(mcParticles);
 
   (*eventvariables)["nJets"]            = validJets.size ();
@@ -280,8 +286,6 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
   (*eventvariables)["jetVeto2022"] = jetVeto2022;
 
   isFirstEvent_ = false;
-
-  f_jetVeto->Close();
 }
 
 unsigned

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -194,10 +194,9 @@ def customize (process,
         process.TriggerWeightProducer.produceTrackLeg = cms.bool(False)
         process.TriggerWeightProducer.produceGrandOr = cms.bool(True)
 
-        #setFiducialMaps (process, electrons="OSUT3Analysis/Configuration/data/electronFiducialMap_2018_data.root", muons="OSUT3Analysis/Configuration/data/muonFiducialMap_2018_data.root")
-        #setThresholdForFiducialMapVeto (process, 2.0)
-        #setUseEraByEraFiducialMaps (process, True)
-
+        setFiducialMaps (process, electrons="OSUT3Analysis/Configuration/data/electronFiducialMap_2022F_data.root", muons="OSUT3Analysis/Configuration/data/muonFiducialMap_2022F_data.root")
+        setThresholdForFiducialMapVeto (process, 2.0)
+        setUseEraByEraFiducialMaps (process, True)
         setMissingHitsCorrection (process, "uncorrected")
 
     elif runPeriod == "2023":
@@ -249,7 +248,6 @@ def customize (process,
         process.TriggerWeightProducer.target          =  cms.string  ("")
         process.TriggerWeightProducer.produceMetLeg = cms.bool(False)
         process.TriggerWeightProducer.produceTrackLeg = cms.bool(False)
-        process.TriggerWeightProducer.produceGrandOr = cms.bool(False)
 
     if not applyMissingHitsCorrections:
         setMissingHitsCorrection (process, "uncorrected")


### PR DESCRIPTION
delete jet veto map histograms after us to save memory

fix fiducial map in customize.py for 2022