### PR TITLE
Track isolation cut update

### DIFF
--- a/StandardAnalysis/python/Cuts.py
+++ b/StandardAnalysis/python/Cuts.py
@@ -652,8 +652,9 @@ cutTrkIso = cms.PSet(
 )
 if not UseCandidateTracks:
     if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
-        cutTrkIso.cutString = cms.string (" ((pfIsolationDR03_.chargedHadronIso + pfIsolationDR03_.puChargedHadronIso) / pt) < 0.05")
-    
+        # This cut does something very similar to the old trackIsoNoPUDRp3. pfIsolationDR03_.chargedHadronIso sums the pT of all PF charged pions that are compatible to the PV in a DR 0.3 cone around an IsolatedTrack. The 0.05 requirement is the same as the one in the HLT_MET105_IsoTrk50 path. In this way, the track isolation is still PU independent, which makes the efficiency of the cut higher.
+        cutTrkIso.cutString = cms.string (" (pfIsolationDR03_.chargedHadronIso / pt) < 0.05")
+
 cutTrkGsfTrkVeto = cms.PSet(
     inputCollection = cms.vstring("tracks"),
     cutString = cms.string("dRToMatchedGsfTrack > 0.15"),

--- a/StandardAnalysis/python/HistogramDefinitions.py
+++ b/StandardAnalysis/python/HistogramDefinitions.py
@@ -264,6 +264,12 @@ TrackExtraHistograms = cms.PSet(
             inputVariables = cms.vstring("caloNewNoPUDRp5CentralCalo / p"),
             ),
         cms.PSet (
+            name = cms.string("trackCaloJetEnergy"),
+            title = cms.string("Isolation energy calculated using matchedCaloJetEmEnergy+matchedCaloJetHadEnergy"),
+            binsX = cms.untracked.vdouble(100, 0, 100),
+            inputVariables = cms.vstring("matchedCaloJetEmEnergy + matchedCaloJetHadEnergy"),
+            ),
+        cms.PSet (
             name = cms.string("trackPtError"),
             title = cms.string("ptError;#sigma(p_{T}) [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 100),


### PR DESCRIPTION
This fixes the track isolation cut using the IsolatedTracks utilities. Before, tracks coming from PU were contributing to the isolation calculation. This was removed.

Also adds a new histogram to track the calorimeter energy associated to tracks using the IsolatedTracks `matchedCaloJetEmEnergy` and `matchedCaloJetHadEnergy`. This is to test the ecalo requirement in the ZToLepProbeTrk selections later.