### PR TITLE
Adding FileInPath to input files

### DIFF
--- a/StandardAnalysis/plugins/EventJetVarProducer.cc
+++ b/StandardAnalysis/plugins/EventJetVarProducer.cc
@@ -59,8 +59,6 @@ private:
   bool jetTightID (const TYPE(jets)&) const;
 
   vector<string> triggerNames;
-  bool isCRAB_ = false;
-  
 };
 
 EventJetVarProducer::EventJetVarProducer(const edm::ParameterSet &cfg) :
@@ -76,8 +74,6 @@ EventJetVarProducer::EventJetVarProducer(const edm::ParameterSet &cfg) :
   tokenMuons_       =  consumes<vector<TYPE(muons)> >            (collections_.getParameter<edm::InputTag>  ("muons"));
 
   triggerNames = cfg.getParameter<vector<string> >("triggerNames");
-  isCRAB_ = cfg.getParameter<bool>("isCRAB");
-
 }
 
 EventJetVarProducer::~EventJetVarProducer() {}
@@ -137,9 +133,7 @@ EventJetVarProducer::AddVariables (const edm::Event &event, const edm::EventSetu
   edm::Handle<edm::TriggerResults> triggerBits;
   event.getByToken(tokenTriggerBits_, triggerBits);
 
-  string jetVetoName = "";
-  if (isCRAB_) {jetVetoName = "Summer22EE_23Sep2023_RunEFG_v1.root";}
-  else {jetVetoName = "/data/users/mcarrigan/condor/run3Inputs/Summer22EE_23Sep2023_RunEFG_v1.root";}
+  string jetVetoName = edm::FileInPath("OSUT3Analysis/Configuration/data/Summer22EE_23Sep2023_RunEFG_v1.root").fullPath();
   TFile* f_jetVeto = TFile::Open(jetVetoName.c_str(), "read");
   TH2D* jetVetoMap = (TH2D*)f_jetVeto->Get("jetvetomap");
 

--- a/StandardAnalysis/plugins/TriggerWeightProducer.cc
+++ b/StandardAnalysis/plugins/TriggerWeightProducer.cc
@@ -59,7 +59,7 @@ private:
 
 TriggerWeightProducer::TriggerWeightProducer(const edm::ParameterSet &cfg) :
   EventVariableProducer (cfg),
-  efficiencyFile_       (cfg.getParameter<string> ("efficiencyFile")),
+  efficiencyFile_       (cfg.getParameter<edm::FileInPath> ("efficiencyFile").fullPath()),
   dataset_              (cfg.getParameter<string> ("dataset")),
   target_               (cfg.getParameter<string> ("target")),
   inclusiveMetTriggers_ (cfg.getParameter<vector<string> > ("inclusiveMetTriggers")),

--- a/StandardAnalysis/python/LeptonScaleFactors.py
+++ b/StandardAnalysis/python/LeptonScaleFactors.py
@@ -230,8 +230,10 @@ muonScaleFactors2022 = cms.VPSet (
 
 ElectronScaleFactorProducer = {
     'name'         : 'ObjectScalingFactorProducer',
-    'electronFile' : cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/electronSFs.root'),
-    'muonFile'     : cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/muonSFs.root'),
+    # 'electronFile' : cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/electronSFs.root'),
+    # 'muonFile'     : cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/muonSFs.root'),
+    'electronFile' : cms.FileInPath('OSUT3Analysis/AnaTools/data/electronSFs.root'),
+    'muonFile'     : cms.FileInPath('OSUT3Analysis/AnaTools/data/muonSFs.root'),
     #'trackFile'    : cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/trackSFs.root'),
     'scaleFactors' : electronScaleFactors2015,
 }

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -15,19 +15,18 @@ def customize (process,
                applyTriggerReweighting = True,
                applyMissingHitsCorrections = True,
                runMETFilters = True,
-               runEcalBadCalibFilters = True,
-               isCRAB = False):
+               runEcalBadCalibFilters = True):
 
     if osusub.batchMode and (osusub.datasetLabel in types) and types[osusub.datasetLabel] != "signalMC":
         applyISRReweighting = False
 
     if runPeriod == "2015":
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
         process.PUScalingFactorProducer.target = cms.string ("data2015")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2015Up")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2015Down")
 
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia', 'SingleMu_2015D')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -35,7 +34,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(False) # Pythia6 + Geant style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
         process.TriggerWeightProducer.dataset = cms.string('SingleMu_2015D')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -49,12 +48,12 @@ def customize (process,
         setMissingHitsCorrection (process, "2015")
 
     elif runPeriod == "2016BC":
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
         process.PUScalingFactorProducer.target = cms.string ("data2016_BC")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2016_BCUp")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2016_BCDown")
 
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia', 'SingleMu_2016')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -62,7 +61,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(False) # Pythia6 + Geant style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
         process.TriggerWeightProducer.dataset = cms.string('SingleMu_2016BC')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -80,12 +79,12 @@ def customize (process,
             process.L1PrefiringWeightProducer.DataEra = cms.string("2016BtoH")
 
     elif runPeriod == "2016DEFGH":
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
         process.PUScalingFactorProducer.target = cms.string ("data2016_DEFGH")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2016_DEFGHUp")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2016_DEFGHDown")
 
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia', 'SingleMu_2016')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -93,7 +92,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(False) # Pythia6 + Geant style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
         process.TriggerWeightProducer.dataset = cms.string('SingleMu_2016DEFGH')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -111,12 +110,12 @@ def customize (process,
             process.L1PrefiringWeightProducer.DataEra = cms.string("2016BtoH")
 
     elif runPeriod == "2017":
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
         process.PUScalingFactorProducer.target = cms.string ("data2017")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2017Up")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2017Down")
 
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia8_94X', 'SingleMu_2017')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -124,7 +123,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(True) # Pythia8 style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
         process.TriggerWeightProducer.dataset = cms.string('SingleMu_2017')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu_94X')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -143,12 +142,12 @@ def customize (process,
             process.L1PrefiringWeightProducer.DataEra = cms.string("2017BtoF")
 
     elif runPeriod == "2018":
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run2.root')
         process.PUScalingFactorProducer.target = cms.string ("data2018")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2018Up")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2018Down")
 
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia8_102X', 'SingleMu_2018')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -156,7 +155,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(True) # Pythia8 style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run2.root')
         process.TriggerWeightProducer.dataset = cms.string('SingleMu_2018')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu_102X')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -172,15 +171,13 @@ def customize (process,
 
     elif runPeriod == "2022":
         
-        if not isCRAB: process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
-        else: process.PUScalingFactorProducer.PU = cms.string ('pu_disappTrks_run3.root')
+        process.PUScalingFactorProducer.PU = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2022")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2022Up")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2022Down")
         process.PUScalingFactorProducer.dataset = cms.string ("mc2022_22Sep2023") # This is usually not added in here, but it makes things easier
 
-        if not isCRAB: process.ISRWeightProducer.weightFile = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run3.root')
-        else: process.ISRWeightProducer.weightFile = cms.string ('isrWeight_disappTrks_run3.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run3.root')
         process.ISRWeightProducer.weightHist = cms.vstring('Muon_2022F')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -188,8 +185,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(True) # Pythia8 style
 
-        if not isCRAB: process.TriggerWeightProducer.efficiencyFile = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run3.root')
-        else: process.TriggerWeightProducer.efficiencyFile = cms.string ('triggerEfficiencies_disappTrks_run3.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run3.root')
         process.TriggerWeightProducer.dataset = cms.string('Muon_2022')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu_2022')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -204,14 +200,14 @@ def customize (process,
 
     elif runPeriod == "2023":
 
-        process.PUScalingFactorProducer.PU     = cms.string (os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
+        process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2023")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2023Up")
         process.PUScalingFactorProducer.targetDown = cms.string ("data2023Down")
         process.PUScalingFactorProducer.dataset = cms.string ("mc2023_22Sep2023") # This is usually not added in here, but it makes things easier
 
         # These come from the 2018 corrections - need to be fixed
-        process.ISRWeightProducer.weightFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
+        process.ISRWeightProducer.weightFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root')
         process.ISRWeightProducer.weightHist = cms.vstring('madgraphOverPythia8_102X', 'SingleMu_2018')
         process.ISRWeightProducer.pdgIds = cms.vint32(1000022, 1000024)
         process.ISRWeightProducer.motherIdsToReject = cms.vint32()
@@ -219,7 +215,7 @@ def customize (process,
 
         process.LifetimeWeightProducer.requireLastNotFirstCopy = cms.bool(True) # Pythia8 style
 
-        process.TriggerWeightProducer.efficiencyFile = cms.string(os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run3.root')
+        process.TriggerWeightProducer.efficiencyFile = cms.FileInPath ('DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run3.root')
         process.TriggerWeightProducer.dataset = cms.string('Muon_2023')
         process.TriggerWeightProducer.target = cms.string('WJetsToLNu_2023')
         process.TriggerWeightProducer.inclusiveMetTriggers = triggersMetInclusive
@@ -234,19 +230,19 @@ def customize (process,
         setMissingHitsCorrection (process, "uncorrected")
 
     if not applyPUReweighting:
-        process.PUScalingFactorProducer.PU     = cms.string ("")
+        # process.PUScalingFactorProducer.PU     = cms.FileInPath ("") # Path of FileInPath can't be empty; module won't do anything because the rest is empty
         process.PUScalingFactorProducer.target = cms.string ("")
         process.PUScalingFactorProducer.targetUp = cms.string ("")
         process.PUScalingFactorProducer.targetDown = cms.string ("")
 
     if not applyISRReweighting:
-        process.ISRWeightProducer.weightFile = cms.string("")
+        # process.ISRWeightProducer.weightFile = cms.FileInPath("") # Path of FileInPath can't be empty; module won't do anything because the rest is empty
         process.ISRWeightProducer.weightHist = cms.vstring()
 
     print(process.ISRWeightProducer.weightFile, process.ISRWeightProducer.weightHist)
 
     if not applyTriggerReweighting:
-        process.TriggerWeightProducer.efficiencyFile  =  cms.string  ("")
+        # process.TriggerWeightProducer.efficiencyFile  =  cms.FileInPath  ("") # Path of FileInPath can't be empty; module won't do anything because the rest is empty
         process.TriggerWeightProducer.dataset         =  cms.string  ("")
         process.TriggerWeightProducer.target          =  cms.string  ("")
         process.TriggerWeightProducer.produceMetLeg = cms.bool(False)


### PR DESCRIPTION
This PR changes the paths of files in modules to accept the format `Package/Sub-Package/data/filename` using the `edm::FileInPath` type. This removes the need to send extra input files to CRAB and to use the `isCRAB` option in the `customize.py` file.

Tested locally and with CRAB several times with different cases, and everything worked as expected.