### PR TITLE
Changes to allow MiniAOD only processing

### DIFF
--- a/BackgroundEstimation/plugins/EventTPProducer.cc
+++ b/BackgroundEstimation/plugins/EventTPProducer.cc
@@ -373,8 +373,12 @@ EventTPProducer<osu::Electron>::passesVeto (const osu::Track &probe) const
   bool passes = probe.deltaRToClosestPFElectron () > 0.15
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM // Verification Needed !
-  bool passes = probe.deltaRToClosestPFElectron () > 0.15
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+  bool passes = probe.deltaRToClosestElectron () > 0.15
+             && probe.caloNewNoPUDRp5CentralCalo () < 10.0
+             && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
+#elif DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
+  bool passes = probe.deltaRToClosestElectron () > 0.15
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
 #else
@@ -392,7 +396,9 @@ EventTPProducer<osu::Electron>::passesLooseVeto (const osu::Track &probe) const
   bool passes = probe.deltaRToClosestVetoElectron () > 0.15
 #if DATA_FORMAT == MINI_AOD_2017
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM // Verification Needed !
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+             && probe.caloNewNoPUDRp5CentralCalo () < 10.0
+#elif DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
 #else
              && probe.caloNewNoPUDRp5CentralCalo () < 10.0
@@ -416,8 +422,8 @@ EventTPProducer<osu::Muon>::passesVeto (const osu::Track &probe) const
 #if DATA_FORMAT == MINI_AOD_2017
   bool passes = probe.deltaRToClosestPFMuon () > 0.15
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
-#elif DATA_FORMAT == MINI_AOD_2022  // Verification Needed !
-  bool passes = probe.deltaRToClosestPFMuon () > 0.15
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
+  bool passes = probe.deltaRToClosestMuon () > 0.15
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
 #else
   bool passes = probe.deltaRToClosestMuon () > 0.15
@@ -443,8 +449,13 @@ EventTPProducer<osu::Electron, osu::Tau>::passesVeto (const osu::Track &probe) c
              && probe.dRMinJet () > 0.5
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM // Verification needed !
-  bool passes = probe.deltaRToClosestPFChHad () > 0.15
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+  bool passes = probe.deltaRToClosestTauHad () > 0.15
+             && probe.dRMinJet () > 0.5
+             && probe.caloNewNoPUDRp5CentralCalo () < 10.0
+             && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
+#elif DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
+  bool passes = probe.deltaRToClosestTauHad () > 0.15
              && probe.dRMinJet () > 0.5
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
@@ -464,7 +475,9 @@ EventTPProducer<osu::Electron, osu::Tau>::passesLooseVeto (const osu::Track &pro
   bool passes = probe.deltaRToClosestVetoElectron () > 0.15
 #if DATA_FORMAT == MINI_AOD_2017
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM //Verification needed
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+             && probe.caloNewNoPUDRp5CentralCalo () < 10.0
+#elif DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
 #else
              && probe.caloNewNoPUDRp5CentralCalo () < 10.0
@@ -481,8 +494,13 @@ EventTPProducer<osu::Muon, osu::Tau>::passesVeto (const osu::Track &probe) const
              && probe.dRMinJet () > 0.5
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM //Verification needed
-  bool passes = probe.deltaRToClosestPFChHad () > 0.15
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+  bool passes = probe.deltaRToClosestTauHad () > 0.15
+             && probe.dRMinJet () > 0.5
+             && probe.caloNewNoPUDRp5CentralCalo () < 10.0
+             && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
+#elif DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
+  bool passes = probe.deltaRToClosestTauHad () > 0.15
              && probe.dRMinJet () > 0.5
              && (probe.matchedCaloJetEmEnergy() + probe.matchedCaloJetHadEnergy()) < 10.0
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;

--- a/README.md
+++ b/README.md
@@ -1,38 +1,47 @@
-## 'Full' recipe including osusub.py
+## 'Full' recipe including osusub.py: AOD+MiniAOD skim
 ```
-cmsrel CMSSW_12_4_11_patch3
-cd CMSSW_12_4_11_patch3/src
+cmsrel CMSSW_13_0_13
+cd CMSSW_13_0_13/src
 cmsenv
 git-cms-init
-git cms-addpkg IOPool/Input
-
-sed -i '/assert(readEventSucceeded)/s/^/\/\//' IOPool/Input/src/PoolSource.cc
 
 git clone https://github.com/OSU-CMS/DisappTrksML.git
 git clone https://github.com/OSU-CMS/DisappTrks.git
 git clone https://github.com/OSU-CMS/OSUT3Analysis.git
+
+cd DisappTrksML
+git checkout tags/cmssw_13_0_13
+cd ../DisappTrks
+git checkout update_CMSSW_13
+cd ../OSUT3Analysis
+git checkout update_CMSSW_13
+cd ..
 
 OSUT3Analysis/AnaTools/scripts/setupFramework.py -f MINI_AOD_2022 -c DisappTrks/StandardAnalysis/interface/CustomDataFormat.h
 
 scramv1 b -j 9
 ```
 
-### Recipie when running AOD/MINIAOD Merger (NoCuts)
+## 'Full' recipe including osusub.py: MiniAOD only
 ```
-cmsrel CMSSW_12_4_11_patch3
-cd CMSSW_12_4_11_patch3/src
+cmsrel CMSSW_13_0_13
+cd CMSSW_13_0_13/src
 cmsenv
 git-cms-init
-git cms-addpkg IOPool/Input
-
-sed -i '/assert(readEventSucceeded)/s/^/\/\//' IOPool/Input/src/PoolSource.cc
 
 git clone https://github.com/OSU-CMS/DisappTrksML.git
 git clone https://github.com/OSU-CMS/DisappTrks.git
 git clone https://github.com/OSU-CMS/OSUT3Analysis.git
-git checkout -b eventMask origin/eventMask
 
-OSUT3Analysis/AnaTools/scripts/setupFramework.py -f MINI_AOD_2022 -c DisappTrks/StandardAnalysis/interface/CustomDataFormat.h
+cd DisappTrksML
+git checkout tags/cmssw_13_0_13
+cd ../DisappTrks
+git checkout update_CMSSW_13
+cd ../OSUT3Analysis
+git checkout update_CMSSW_13
+cd ..
+
+OSUT3Analysis/AnaTools/scripts/setupFramework.py -f MINI_AOD_ONLY_2022 -c DisappTrks/StandardAnalysis/interface/CustomDataFormat.h
 
 scramv1 b -j 9
 ```

--- a/StandardAnalysis/python/Cuts.py
+++ b/StandardAnalysis/python/Cuts.py
@@ -6,6 +6,7 @@ from DisappTrks.StandardAnalysis.METFilters import *
 from DisappTrks.TriggerAnalysis.AllTriggers import *
 from OSUT3Analysis.Configuration.cutUtilities import *
 from DisappTrks.StandardAnalysis.protoConfig_cfg import UseCandidateTracks
+from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
 import os
 
 ##############################
@@ -721,6 +722,10 @@ cutTrkEcalo = cms.PSet(
     cutString = cms.string("caloNewNoPUDRp5CentralCalo < 10"),
     numberRequired = cms.string(">= 1"),
 )
+# If using MiniAOD only processing, the ecalo cut has to be changed to the CMSSW standard
+if dataFormat == 'MINI_AOD_ONLY_2022_CUSTOM':
+    cutTrkEcalo.cutString = cms.string ("(matchedCaloJetEmEnergy + matchedCaloJetHadEnergy) < 10")
+
 cutTrkNMissOut0 = cms.PSet(
     inputCollection = cms.vstring("tracks"),
     cutString = cms.string("hitAndTOBDrop_bestTrackMissingOuterHits >= 0"),
@@ -761,6 +766,13 @@ cutTrkEcaloInv50 = cms.PSet(
     cutString = cms.string("caloNewNoPUDRp5CentralCalo > 50"),
     numberRequired = cms.string(">= 1"),
 )
+# If using MiniAOD only processing, the ecalo cut has to be changed to the CMSSW standard
+if dataFormat == 'MINI_AOD_ONLY_2022_CUSTOM':
+    cutTrkEcaloInv.cutString = cms.string ("(matchedCaloJetEmEnergy + matchedCaloJetHadEnergy) > 10")
+# If using MiniAOD only processing, the ecalo cut has to be changed to the CMSSW standard
+if dataFormat == 'MINI_AOD_ONLY_2022_CUSTOM':
+    cutTrkEcaloInv50.cutString = cms.string ("(matchedCaloJetEmEnergy + matchedCaloJetHadEnergy) > 50")
+
 cutTrkNMissOutInv = cms.PSet(
     inputCollection = cms.vstring("tracks"),
     cutString = cms.string("hitAndTOBDrop_bestTrackMissingOuterHits <= 2"),

--- a/StandardAnalysis/python/miniAOD_124X_Samples.py
+++ b/StandardAnalysis/python/miniAOD_124X_Samples.py
@@ -115,7 +115,7 @@ dataset_names_bkgd = {
     'TBbartoLplusNuBbar_2022EE' : '/TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'TbarQtoLNu_2022EE' : '/TbarQtoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'TQbartoLNu_2022EE' : '/TQbartoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
-    'TbarWplusto2L2Nu_2022EE' : '',
+    'TbarWplusto2L2Nu_2022EE' : '/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'TbarWplustoLNu2Q_2022EE' : '/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'TWminusto2L2Nu_2022EE' : '/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'TWminustoLNu2Q_2022EE' : '/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',

--- a/ToyModels/plugins/ParticleGunVarProducer.cc
+++ b/ToyModels/plugins/ParticleGunVarProducer.cc
@@ -198,8 +198,8 @@ ParticleGunVarProducer<osu::Track,TYPE(muons)>::passesVeto (const osu::Track &pr
 #if DATA_FORMAT == MINI_AOD_2017
   bool passes = probe.deltaRToClosestPFMuon () > 0.15
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
-  bool passes = probe.deltaRToClosestPFMuon () > 0.15
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
+  bool passes = probe.deltaRToClosestMuon () > 0.15
              && probe.hitAndTOBDrop_bestTrackMissingOuterHits () >= 3.0;
 #else
   bool passes = probe.deltaRToClosestMuon () > 0.15

--- a/TriggerAnalysis/plugins/EventTriggerVarProducer.cc
+++ b/TriggerAnalysis/plugins/EventTriggerVarProducer.cc
@@ -358,7 +358,7 @@ bool EventTriggerVarProducer::isGoodTrack(const TYPE(tracks) &track,
                  track.hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::TRACK_HITS) == 0 &&
                  track.pfIsolationDR03().chargedHadronIso() / track.pt() < 0.01); // replaces trackIsoNoPUDRp3/pt
 
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM // Verification needed !
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM // Verification needed !
   bool result = (fabs(track.eta()) < 2.5 &&
                  track.isHighPurityTrack() && 
                  fabs(track.dxy()) < 0.2 &&


### PR DESCRIPTION
This PR adds changes to allow for the processing of data using the MiniAOD datasets only.

Checked for differences when processing with the MiniAOD+AOD skims and found none.