### PR TITLE
Adding correct GTs for all early Run 3 data

### DIFF
--- a/StandardAnalysis/python/protoConfig_cfg.py
+++ b/StandardAnalysis/python/protoConfig_cfg.py
@@ -6,6 +6,10 @@ import os
 import copy
 import subprocess
 
+dataYear = '2022'
+dataEra = 'F' # This is the campaign name for MC
+runWithData = True # Set this to False for MC
+
 data_global_tag = '76X_dataRun2_v15'
 mc_global_tag = '76X_mcRun2_asymptotic_v12'
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
@@ -21,8 +25,25 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_"):
     data_global_tag = '124X_dataRun3_Prompt_v4'
     mc_global_tag = '124X_mcRun3_2022_realistic_v12'
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"): # This is set for 2022 postEE campaign; if using 2022 preEE samples, change it
-    data_global_tag = '130X_dataRun3_PromptAnalysis_v1'
-    mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
+    if runWithData:
+        if dataYear == '2022':
+            if dataEra in ['C','D','E']:
+                data_global_tag = '130X_dataRun3_v2'
+            if dataEra in ['F','G']:
+                data_global_tag = '130X_dataRun3_PromptAnalysis_v1'
+        if dataYear == '2023':
+            data_global_tag = '130X_dataRun3_PromptAnalysis_v1'
+    else:
+        if dataYear == '2022':
+            if dataEra in ['preEE']:
+                mc_global_tag = '130X_mcRun3_2022_realistic_v5'
+            if dataEra in ['postEE']:
+                mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
+        if dataYear == '2023':
+            if dataEra in ['preBPix']:
+                mc_global_tag = '130X_mcRun3_2023_realistic_v14'
+            if dataEra in ['postBPix']:
+                mc_global_tag = '130X_mcRun3_2023_realistic_postBPix_v2'
 ################################################################################
 # Create the skeleton process
 ################################################################################
@@ -67,9 +88,9 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_V
         # "file:/share/scratch0/borzari/CMSSW_12_4_11_patch3/src/DisappTrks/CandidateTrackProducer/test/candidateTrack_test.root",
         # "file:condor/SignalMC/Run3/2022/step4/CandidateTrackProducerNoSkimming/100cm/700GeV/oneHist/hist_444.root",
     ])
-    process.source.secondaryFileNames = cms.untracked.vstring([
-        "file:/data/users/borzari/condor/SignalMC/Run3/2022/step3/100cm/700GeV/AMSB_chargino_M_700GeV_CTau_100cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/hist_19.root",
-    ])
+    # process.source.secondaryFileNames = cms.untracked.vstring([
+    #     "file:/data/users/borzari/condor/SignalMC/Run3/2022/step3/100cm/700GeV/AMSB_chargino_M_700GeV_CTau_100cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/hist_19.root",
+    # ])
 process.TFileService = cms.Service ('TFileService',
     fileName = cms.string ('hist.root')
 )
@@ -111,14 +132,20 @@ process.MessageLogger.cerr.OSUJetProducer = cms.untracked.PSet(
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, mc_global_tag, '')
-if osusub.batchMode and (osusub.datasetLabel in types) and (types[osusub.datasetLabel] == "data"):
-    if osusub.datasetLabel.endswith('2018D'):
-        data_global_tag = '102X_dataRun2_Prompt_v13'
+# process.GlobalTag = GlobalTag(process.GlobalTag, mc_global_tag, '')
+# if (osusub.batchMode and (osusub.datasetLabel in types) and (types[osusub.datasetLabel] == "data")):
+#     if osusub.datasetLabel.endswith('2018D'):
+#         data_global_tag = '102X_dataRun2_Prompt_v13'
+#     print("# Global tag: " + data_global_tag)
+#     process.GlobalTag = GlobalTag(process.GlobalTag, data_global_tag, '')
+# else:
+#     print("# Global tag: " + mc_global_tag)
+if runWithData:
     print("# Global tag: " + data_global_tag)
     process.GlobalTag = GlobalTag(process.GlobalTag, data_global_tag, '')
 else:
     print("# Global tag: " + mc_global_tag)
+    process.GlobalTag = GlobalTag(process.GlobalTag, mc_global_tag, '')
 ################################################################################
 
 process.metFilterPath = cms.Path ()


### PR DESCRIPTION
This PR adds some new variables to manually set the correct global tags for all distinct cases of Run 3 data processing. The GTs are extracted from [here](https://docs.google.com/presentation/d/1F4ndU7DBcyvrEEyLfYqb29NGkBPs20EAnBxe_l7AEII/edit#slide=id.g289f499aa6b_2_52) for 2022 and [here](https://docs.google.com/presentation/d/1TjPem5jX0fzqvTGl271_nQFoVBabsrdrO0i8Qo1uD5E/edit#slide=id.g289f499aa6b_2_58) for 2023.

`dataYear`: valid for both, collected data and MC;
`dataEra`: is the regular era for data, e.g., E, F or G, and the campaign name for MC, e.g., preEE or postEE;
`runWithData`: switch to use collected data GTs or MC GTs.

The default values are set to run with the 2022F data GT.

Lines https://github.com/OSU-CMS/DisappTrks/blob/update_CMSSW_13/StandardAnalysis/python/protoConfig_cfg.py#L114-L121 were commented out, because even when adding an `or runWithData` in the data case, things inside `OSUT3Analysis.DBTools.osusub_cfg` would not be defined and the code doesn't run.

Checked the different cases and the script is picking up the correct GTs.

Please, while we don't find an automatic solution for GT setting with CRAB, remember to manually set the correct values for the new variables, even when running with osusub. The GT picking is manual for now.

Also commented out the secondary input files when running with CMSSW 12_4_X or 13_0_X.