### PR TITLE
Changing jet ID selections to use common utils and selection changes

### DIFF
--- a/BackgroundEstimation/python/ElectronTagProbeSelections.py
+++ b/BackgroundEstimation/python/ElectronTagProbeSelections.py
@@ -264,6 +264,8 @@ createHitsVariations (ZtoEleProbeTrkWithFilter,   "ZtoEleProbeTrkWithFilter")
 createHitsVariations (ZtoEleProbeTrkWithSSFilter, "ZtoEleProbeTrkWithSSFilter")
 createHitsVariations (ZtoEleProbeTrkWithLooseFilter,   "ZtoEleProbeTrkWithLooseFilter")
 createHitsVariations (ZtoEleProbeTrkWithLooseSSFilter, "ZtoEleProbeTrkWithLooseSSFilter")
+createHitsVariations (ElectronTagPt35NoJetCuts,            "ElectronTagPt35NoJetCuts")
+createHitsVariations (ElectronTagPt35NoJetCutsMetTrig,     "ElectronTagPt35NoJetCutsMetTrig")
 
 # create copies of all above selections with the fiducial electron/muon cuts removed
 for selection in list (locals ()):

--- a/BackgroundEstimation/python/MuonTagProbeSelections.py
+++ b/BackgroundEstimation/python/MuonTagProbeSelections.py
@@ -260,6 +260,8 @@ createHitsVariations (ZtoMuProbeTrkWithFilter,   "ZtoMuProbeTrkWithFilter")
 createHitsVariations (ZtoMuProbeTrkWithSSFilter, "ZtoMuProbeTrkWithSSFilter")
 createHitsVariations (ZtoMuProbeTrkWithLooseFilter,   "ZtoMuProbeTrkWithLooseFilter")
 createHitsVariations (ZtoMuProbeTrkWithLooseSSFilter, "ZtoMuProbeTrkWithLooseSSFilter")
+createHitsVariations (MuonTagPt35NoJetCuts,               "MuonTagPt35NoJetCuts")
+createHitsVariations (MuonTagPt35NoJetCutsMetTrig,        "MuonTagPt35NoJetCutsMetTrig")
 
 # create copies of all above selections with the fiducial electron/muon cuts removed
 for selection in list (locals ()):

--- a/BackgroundEstimation/python/TauTagProbeSelections.py
+++ b/BackgroundEstimation/python/TauTagProbeSelections.py
@@ -325,6 +325,8 @@ createHitsVariations (ZtoTauToMuProbeTrkWithZCuts,     "ZtoTauToMuProbeTrkWithZC
 createHitsVariations (ZtoTauToEleProbeTrkWithZCuts,    "ZtoTauToEleProbeTrkWithZCuts")
 createHitsVariations (ZtoTauToMuDisTrk,                "ZtoTauToMuDisTrk")
 createHitsVariations (ZtoTauToEleDisTrk,               "ZtoTauToEleDisTrk")
+createHitsVariations (TauTagPt55NoJetCuts,             "TauTagPt55NoJetCuts")
+createHitsVariations (TauTagPt55NoJetCutsMetTrig,      "TauTagPt55NoJetCutsMetTrig")
 
 # create copies of all above selections with the fiducial electron/muon cuts removed
 for selection in list (locals ()):

--- a/StandardAnalysis/plugins/EventJetVarProducer.cc
+++ b/StandardAnalysis/plugins/EventJetVarProducer.cc
@@ -459,40 +459,8 @@ EventJetVarProducer::jetLooseSelection (const TYPE(jets) &jet, const vector<TYPE
 bool 
 EventJetVarProducer::jetTightID (const TYPE(jets)& jet) const
 {
-
-  if ( fabs(jet.eta()) <= 2.6 ) {
-    if ( jet.neutralHadronEnergyFraction() >= 0.99 ) return false;
-    if ( jet.neutralEmEnergyFraction() >= 0.90 ) return false;
-    if ( (jet.chargedMultiplicity() + jet.neutralMultiplicity()) <= 1 ) return false;
-    if ( jet.muonEnergyFraction() >= 0.80 ) return false;
-    if ( jet.chargedHadronEnergyFraction() <= 0.01 ) return false;
-    if ( jet.chargedMultiplicity() <= 0 ) return false;
-    if ( jet.chargedEmEnergyFraction() >= 0.80 ) return false; 
-    return true;
-  }
-  else if ( (fabs(jet.eta()) > 2.6) && (fabs(jet.eta()) <= 2.7) ){
-    if ( jet.neutralHadronEnergyFraction() >= 0.90 ) return false;
-    if ( jet.neutralEmEnergyFraction() >= 0.99 ) return false;
-    if ( jet.muonEnergyFraction() >= 0.80 ) return false;
-    if ( jet.chargedMultiplicity() <= 0 ) return false;
-    if ( jet.chargedEmEnergyFraction() >= 0.80 ) return false; 
-    return true;
-  }
-  else if( (fabs(jet.eta()) > 2.7) && (fabs(jet.eta()) <= 3.0) ){
-    if ( jet.neutralHadronEnergyFraction() >= 0.99 ) return false;
-    if ( jet.neutralEmEnergyFraction() >= 0.99 ) return false;
-    if ( jet.neutralMultiplicity() <= 1 ) return false;
-    return true;
-  }
-  else if( (fabs(jet.eta()) > 3.0) && (fabs(jet.eta()) <= 5.0) ) {
-    if ( jet.neutralEmEnergyFraction() >= 0.40 ) return false;
-    if ( jet.neutralMultiplicity() <= 10 ) return false;
-    return true;
-  }
-  else{
-    return false;
-  }
-
+  bool result = anatools::jetPassesTightLepVeto(jet); // This automatically uses the correct jet ID criteria
+  return result;
 }
 
 

--- a/StandardAnalysis/plugins/TrackCollectionAnalyzer.cc
+++ b/StandardAnalysis/plugins/TrackCollectionAnalyzer.cc
@@ -896,8 +896,8 @@ TrackCollectionAnalyzer::disappearingTrackSelection(
     for(const auto &jet : jets) {
       if(jet.pt() > 30 &&
          fabs(jet.eta()) < 4.5 &&
-         (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
-            || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0))) {
+         anatools::jetPassesTightLepVeto(jet) // This automatically uses the correct jet ID criteria
+        ) {
         double dR = deltaR(track, jet);
         if(dRMinJet < 0 || dR < dRMinJet) dRMinJet = dR;
       }
@@ -988,8 +988,8 @@ TrackCollectionAnalyzer::disappearingTrackSelection_Nm2(
     for(const auto &jet : jets) {
       if(jet.pt() > 30 &&
          fabs(jet.eta()) < 4.5 &&
-         (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
-            || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0))) {
+         anatools::jetPassesTightLepVeto(jet) // This automatically uses the correct jet ID criteria
+        ) {
         double dR = deltaR(track, jet);
         if(dRMinJet < 0 || dR < dRMinJet) dRMinJet = dR;
       }
@@ -1241,19 +1241,8 @@ TrackCollectionAnalyzer::MinDRtoJet(const vector<pat::Jet> &jets, const Candidat
     for(const auto &jet : jets) {
       if(jet.pt() > 30 &&
          fabs(jet.eta()) < 4.5 &&
-         (((jet.neutralHadronEnergyFraction()<0.90 && 
-            jet.neutralEmEnergyFraction()<0.90 && 
-            (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && 
-             jet.muonEnergyFraction()<0.8) && 
-             ((fabs(jet.eta())<=2.4 && 
-               jet.chargedHadronEnergyFraction()>0 && 
-               jet.chargedMultiplicity()>0 && 
-               jet.chargedEmEnergyFraction()<0.90) || 
-               fabs(jet.eta())>2.4) && 
-             fabs(jet.eta())<=3.0) || 
-             (jet.neutralEmEnergyFraction()<0.90 && 
-              jet.neutralMultiplicity()>10 && 
-              fabs(jet.eta())>3.0))) {
+         anatools::jetPassesTightLepVeto(jet) // This automatically uses the correct jet ID criteria
+        ) {
         double dR = deltaR(track, jet);
         if(dRMinJet < 0 || dR < dRMinJet) dRMinJet = dR;
       }

--- a/StandardAnalysis/python/EventSelections.py
+++ b/StandardAnalysis/python/EventSelections.py
@@ -456,6 +456,7 @@ cutsToRemove = [
     ]
 removeCuts(candTrkIdElecPt35.cuts, cutsToRemove)
 
+createHitsVariations (candTrkIdElecPt35, "candTrkIdElecPt35")
 
 # Use this selection for the electron background estimate.
 candTrkIdElecPt35NoMet = copy.deepcopy(candTrkIdElecPt35)
@@ -488,6 +489,7 @@ cutsToRemove = [
     ]
 removeCuts(candTrkIdMuPt35.cuts, cutsToRemove)
 
+createHitsVariations (candTrkIdMuPt35, "candTrkIdMuPt35")
 
 # Use this selection for the electron background estimate.
 candTrkIdMuPt35NoMet = copy.deepcopy(candTrkIdMuPt35)
@@ -519,6 +521,7 @@ cutsToRemove = [
     ]
 removeCuts(candTrkIdTauPt55.cuts, cutsToRemove)
 
+createHitsVariations (candTrkIdTauPt55, "candTrkIdTauPt55")
 
 # Use this selection for the electron background estimate.
 candTrkIdTauPt55NoMet = copy.deepcopy(candTrkIdTauPt55)

--- a/StandardAnalysis/test/crab_StdAnaSelections.py
+++ b/StandardAnalysis/test/crab_StdAnaSelections.py
@@ -13,13 +13,8 @@ config.General.requestName = 'Skimming' # this is the name of the crab folder; u
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'config_2022_cfg.py'
 config.JobType.allowUndistributedCMSSW = True
-# List of files that are in the repos, but are used for the selections
-config.JobType.inputFiles = [os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/electronSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/muonSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt', '/data/users/mcarrigan/condor/run3Inputs/Summer22EE_23Sep2023_RunEFG_v1.root']
 
-# always use MINIAOD as inputDataset and AOD as secondaryInputDataset
-
-config.Data.inputDataset = '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22EEMiniAODv3-forPOG_124X_mcRun3_2022_realistic_postEE_v1-v3/MINIAODSIM'
-config.Data.secondaryInputDataset = '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22EEDRPremix-forPOG_124X_mcRun3_2022_realistic_postEE_v1-v3/AODSIM'
+config.Data.inputDataset = '/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM'
 
 config.Data.inputDBS = 'global'
 # config.Data.inputDBS = 'phys03'
@@ -40,5 +35,5 @@ config.Data.outputDatasetTag = 'Skimming' # this is just an example; it will be 
 #config.Data.outLFNDirBase = '/store/group/phys_exotica/disappearingTracks/'
 #config.Site.storageSite = 'T2_CH_CERN'
 
-# config.Data.outLFNDirBase = '/store/user/borzari/'
-# config.Site.storageSite = 'T2_BR_SPRACE'
+config.Data.outLFNDirBase = '/store/user/borzari/'
+config.Site.storageSite = 'T2_BR_SPRACE'

--- a/TriggerAnalysis/plugins/HLTrigEffAnalyzer.cc
+++ b/TriggerAnalysis/plugins/HLTrigEffAnalyzer.cc
@@ -459,18 +459,7 @@ double HLTrigEffAnalyzer::maxJetDeltaPhi(const vector<pat::Jet> &jets) const{
 }
 
 bool HLTrigEffAnalyzer::passJetTightLepVeto(const pat::Jet& jet) const {
-  bool result = (
-                 (jet.neutralHadronEnergyFraction()<0.90 && 
-                  jet.neutralEmEnergyFraction()<0.90 && 
-                  (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 &&
-                  jet.muonEnergyFraction()<0.8
-                 ) 
-                 && 
-                 ((abs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) ||  abs(jet.eta())>2.4) 
-                 && 
-                 abs(jet.eta())<=3.0
-                )|| 
-                (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && abs(jet.eta())>3.0);
+  bool result = anatools::jetPassesTightLepVeto(jet); // This automatically uses the correct jet ID criteria
   return result;
 }
 

--- a/TriggerAnalysis/plugins/L1EmulationInfoPrinter.cc
+++ b/TriggerAnalysis/plugins/L1EmulationInfoPrinter.cc
@@ -65,6 +65,8 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
+#include "OSUT3Analysis/AnaTools/interface/CommonUtils.h"
+
 //
 // class declaration
 //
@@ -526,18 +528,7 @@ bool L1EmulationInfoPrinter::isGoodTrack(const pat::IsolatedTrack &track,
 }*/
 
 bool L1EmulationInfoPrinter::passJetTightLepVeto(const reco::PFJet& jet) const {
-  bool result = (
-                 (jet.neutralHadronEnergyFraction()<0.90 && 
-                  jet.neutralEmEnergyFraction()<0.90 && 
-                  (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 &&
-                  jet.muonEnergyFraction()<0.8
-                 ) 
-                 && 
-                 ((abs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) ||  abs(jet.eta())>2.4) 
-                 && 
-                 abs(jet.eta())<=3.0
-                )|| 
-                (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && abs(jet.eta())>3.0);
+  bool result = anatools::jetPassesTightLepVeto(jet); // This automatically uses the correct jet ID criteria
   return result;
 }
 //define this as a plug-in


### PR DESCRIPTION
This PR changes every place the jet ID criteria was added by hand, to use the method defined in `OSUT3Analysis/AnaTools/interface/CommonUtils.h`.

It also adds some changes to some events selections to be able to easily run over the NLayers variants.