### PR TITLE
Changing muon trigger filter depending on era

### DIFF
--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -209,6 +209,23 @@ def customize (process,
             mc_global_tag = '130X_mcRun3_2022_realistic_v5'
         elif runEra in ['E', 'F', 'G']:
             mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
+
+        if runEra in ['C', 'D']:
+            strOSUMuonProducer = ''
+            strOSUTrackProducer = ''
+            attrs = (vars(process))['_Process__producers']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strOSUMuonProducer = key
+                if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strOSUTrackProducer = key
+            if hasattr (process, strOSUMuonProducer):
+                moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
+                for x in moduleOSUMuonProducer.hltMatchingInfo:
+                    if x.name.value() == "HLT_IsoMu24_v":
+                        x.collection = cms.string("hltIterL3MuonCandidates::HLT")
+                        x.filter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
+            if hasattr (process, strOSUTrackProducer):
+                moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
+                moduleOSUTrackProducer.muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
         
         process.PUScalingFactorProducer.PU = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2022")

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -211,21 +211,24 @@ def customize (process,
             mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
 
         if runEra in ['C', 'D']:
-            strOSUMuonProducer = ''
-            strOSUTrackProducer = ''
+            triggerFiltersMuon = ("hltIterL3MuonCandidates::HLT", "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
+            strsOSUMuonProducer = []
+            strsOSUTrackProducer = []
             attrs = (vars(process))['_Process__producers']
             for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strOSUMuonProducer = key
-                if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strOSUTrackProducer = key
-            if hasattr (process, strOSUMuonProducer):
-                moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
-                for x in moduleOSUMuonProducer.hltMatchingInfo:
-                    if x.name.value() == "HLT_IsoMu24_v":
-                        x.collection = cms.string("hltIterL3MuonCandidates::HLT")
-                        x.filter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
-            if hasattr (process, strOSUTrackProducer):
-                moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
-                moduleOSUTrackProducer.muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
+                if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strsOSUMuonProducer.append(key)
+                if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strsOSUTrackProducer.append(key)
+            for strOSUMuonProducer in strsOSUMuonProducer:
+                if hasattr (process, strOSUMuonProducer):
+                    moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
+                    for x in moduleOSUMuonProducer.hltMatchingInfo:
+                        if x.name.value() == "HLT_IsoMu24_v":
+                            x.collection = cms.string("hltIterL3MuonCandidates::HLT")
+                            x.filter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
+            for strOSUTrackProducer in strsOSUTrackProducer:
+                if hasattr (process, strOSUTrackProducer):
+                    moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
+                    moduleOSUTrackProducer.muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
         
         process.PUScalingFactorProducer.PU = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2022")

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -211,7 +211,6 @@ def customize (process,
             mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
 
         if runEra in ['C', 'D']:
-            triggerFiltersMuon = ("hltIterL3MuonCandidates::HLT", "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
             strsOSUMuonProducer = []
             strsOSUTrackProducer = []
             attrs = (vars(process))['_Process__producers']
@@ -321,8 +320,6 @@ def customize (process,
         # process.ISRWeightProducer.weightFile = cms.FileInPath("") # Path of FileInPath can't be empty; module won't do anything because the rest is empty
         process.ISRWeightProducer.weightHist = cms.vstring()
 
-    print(process.ISRWeightProducer.weightFile, process.ISRWeightProducer.weightHist)
-
     if not applyTriggerReweighting:
         # process.TriggerWeightProducer.efficiencyFile  =  cms.FileInPath  ("") # Path of FileInPath can't be empty; module won't do anything because the rest is empty
         process.TriggerWeightProducer.dataset         =  cms.string  ("")
@@ -363,6 +360,7 @@ def customize (process,
             getattr (process, "EventMuonTPProducer").doJetFilter = cms.bool (doJetFilter)
             getattr (process, "EventMuonTPProducer").triggerCollectionName = cms.string (triggerFiltersMuon[0])
             getattr (process, "EventMuonTPProducer").triggerFilterName = cms.string (triggerFiltersMuon[1])
+            if runPeriod == "2022" and runEra in ['C', 'D']: getattr (process, "EventMuonTPProducer").triggerFilterName = cms.string ("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
             getattr (process, "EventMuonTPProducer").triggerMatchingDR = cms.double (0.3)
             getattr (process, "EventMuonTPProducer").probeTagMatchingDR = cms.double (0.3)
             moveVariableProducer (process, "EventMuonTPProducer", channel)

--- a/TriggerAnalysis/python/AllTriggers.py
+++ b/TriggerAnalysis/python/AllTriggers.py
@@ -151,8 +151,8 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_V
     }
 
     triggerFiltersElectron = ("hltEgammaCandidates::HLT", "hltEle32WPTightGsfTrackIsoFilter")
-    triggerFiltersMuon = ("hltIterL3MuonCandidates::HLT", "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07")
-    triggerFiltersTau = ("hltSelectedPFTausTrackPt30MediumAbsOrRelIsolation1Prong::HLT", "hltPFTau50TrackPt30MediumAbsOrRelIso1Prong")
+    triggerFiltersMuon = ("hltIterL3MuonCandidates::HLT", "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered")
+    triggerFiltersTau = ("hltHpsSinglePFTau20MediumDitauWPDeepTauNoMatchForVBFIsoTau::HLT", "hltHpsOverlapFilterIsoMu24MediumDeepTauPFTau20")
 
 
 # Flat cms.vstring of filters for use in EventTriggerVarProducer


### PR DESCRIPTION
This PR needs to be merged together with https://github.com/OSU-CMS/OSUT3Analysis/pull/264

It adds another customization that depends on the era. The muon trigger path `HLT_IsoMu24_v` filter changes in between eras D and E. The default name of the filter is defined in the `OSUT3Analysis/Configuration/python/CollectionProducer_cff.py` file, and the change on eras C and D is done in the `customize.py`. Tested with eras C and F and the change works fine.