### PR TITLE
Get rid of mentions of L1ETProducer

### DIFF
--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -404,16 +404,17 @@ def customize (process,
         if hasattr (process, "EventTauMETTriggerProducer"):
             customizeForMETTriggerProducer (getattr (process, "EventTauMETTriggerProducer"))
             moveVariableProducer (process, "EventTauMETTriggerProducer", channel)
-
-        if hasattr (process, "EventElectronL1ETMProducer"):
-            customizeForL1ETMProducer (getattr (process, "EventElectronL1ETMProducer"))
-            moveVariableProducer (process, "EventElectronL1ETMProducer", channel)
-        if hasattr (process, "EventMuonL1ETMProducer"):
-            customizeForL1ETMProducer (getattr (process, "EventMuonL1ETMProducer"))
-            moveVariableProducer (process, "EventMuonL1ETMProducer", channel)
-        if hasattr (process, "EventTauL1ETMProducer"):
-            customizeForL1ETMProducer (getattr (process, "EventTauL1ETMProducer"))
-            moveVariableProducer (process, "EventTauL1ETMProducer", channel)
+        
+        if (runPeriod.find("2016") == -1) or (runPeriod.find("2017") == -1)
+            if hasattr (process, "EventElectronL1ETMProducer"):
+                customizeForL1ETMProducer (getattr (process, "EventElectronL1ETMProducer"))
+                moveVariableProducer (process, "EventElectronL1ETMProducer", channel)
+            if hasattr (process, "EventMuonL1ETMProducer"):
+                customizeForL1ETMProducer (getattr (process, "EventMuonL1ETMProducer"))
+                moveVariableProducer (process, "EventMuonL1ETMProducer", channel)
+            if hasattr (process, "EventTauL1ETMProducer"):
+                customizeForL1ETMProducer (getattr (process, "EventTauL1ETMProducer"))
+                moveVariableProducer (process, "EventTauL1ETMProducer", channel)
 
         moveArbitrationToEnd (process, channel)
 


### PR DESCRIPTION
The L1ETMProducers were needed for corrections in 2016 and 2017. They are no longer needed and the inclusion of these producers causes jobs to fail in 2022 and 2023 due to not having the necessary L1 menu information.