### PR TITLE
Implementing 2023 lepton SFs

### DIFF
--- a/ClosureTests/python/config_cfg.py
+++ b/ClosureTests/python/config_cfg.py
@@ -1,5 +1,8 @@
 from DisappTrks.StandardAnalysis.protoConfig_cfg import *
 
+def getNLayersChannelVariations (chName):
+    return [globals()[chName + x] for x in ['NLayers4', 'NLayers5', 'NLayers6plus']]
+
 ################################################################################
 # MET channels
 ################################################################################
@@ -12,6 +15,10 @@ from DisappTrks.StandardAnalysis.protoConfig_cfg import *
 #  add_channels  (process,  [candTrkIdTauPt55],       histSets,  weights,  [],  collMap,  variableProducers,  False)
 #  add_channels  (process,  [candTrkIdTauPt55NoMet],  histSets,  weights,  [],  collMap,  variableProducers,  False)
 
+#  add_channels  (process,  getNLayersChannelVariations("candTrkIdElecPt35"),       histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  getNLayersChannelVariations("candTrkIdMuPt35"),       histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  getNLayersChannelVariations("candTrkIdTauPt55"),       histSets,  weights,  [],  collMap,  variableProducers,  True)
+
 ################################################################################
 # SingleElectron channels
 ################################################################################
@@ -23,11 +30,22 @@ from DisappTrks.StandardAnalysis.protoConfig_cfg import *
 #  add_channels  (process,  [ElectronTagPt35NoJetCuts],         histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  False)
 #  add_channels  (process,  [ElectronTagPt35NoJetCutsMetTrig],  histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  False)
 
+# add_channels  (process,  getNLayersChannelVariations("ZtoEleProbeTrk"),   histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + electronTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoEleProbeTrkWithFilter"),   histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + electronTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoEleProbeTrkWithSSFilter"), histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + electronTPProducer, True)
+
+#  add_channels  (process,  getNLayersChannelVariations("ElectronTagPt35NoJetCuts"),         histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  True)
+#  add_channels  (process,  getNLayersChannelVariations("ElectronTagPt35NoJetCutsMetTrig"),  histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  True)
+
 #  add_channels  (process,  [ZtoTauToEleProbeTrkNLayers4],             histSetsElectron, weightsWithEleSF, scaleFactorProducersWithElectrons, collMap, variableProducers + tauToElectronTPProducer, ignoreSkimmedCollections = True)
 #  add_channels  (process,  [ZtoTauToEleProbeTrkNLayers5],             histSetsElectron, weightsWithEleSF, scaleFactorProducersWithElectrons, collMap, variableProducers + tauToElectronTPProducer, ignoreSkimmedCollections = True)
 #  add_channels  (process,  [ZtoTauToEleProbeTrkNLayers6plus],             histSetsElectron, weightsWithEleSF, scaleFactorProducersWithElectrons, collMap, variableProducers + tauToElectronTPProducer, ignoreSkimmedCollections = True)
 #  add_channels  (process,  [ZtoTauToEleProbeTrkWithZCuts],    histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  False)
 #  add_channels  (process,  [ZtoTauToEleDisTrkNoNMissOutCut],  histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers,  False)
+
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToEleProbeTrk"),   histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + tauToElectronTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToEleProbeTrkWithFilter"),   histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + tauToElectronTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToEleProbeTrkWithSSFilter"), histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers + tauToElectronTPProducer, True)
 
 ################################################################################
 # SingleMuon channels
@@ -40,17 +58,48 @@ from DisappTrks.StandardAnalysis.protoConfig_cfg import *
 #  add_channels  (process,  [MuonTagPt35NoJetCuts],         histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  False)
 #  add_channels  (process,  [MuonTagPt35NoJetCutsMetTrig],  histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  False)
 
+#  add_channels  (process,  getNLayersChannelVariations("ZtoMuProbeTrk"),                   histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + muonTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoMuProbeTrkWithFilter"),         histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + muonTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoMuProbeTrkWithSSFilter"),       histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + muonTPProducer, True)
+
+#  add_channels  (process,  getNLayersChannelVariations("MuonTagPt35NoJetCuts"),         histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  True)
+#  add_channels  (process,  getNLayersChannelVariations("MuonTagPt35NoJetCutsMetTrig"),  histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  True)
+
 #  add_channels  (process,  [ZtoTauToMuProbeTrkNLayers4],                       histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer)
 #  add_channels  (process,  [ZtoTauToMuProbeTrkNLayers5],                       histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer)
 #  add_channels  (process,  [ZtoTauToMuProbeTrkNLayers6plus],                       histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer)
 #  add_channels  (process,  [ZtoTauToMuProbeTrkWithZCuts],    histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  False)
 #  add_channels  (process,  [ZtoTauToMuDisTrkNoNMissOutCut],  histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers,  False)
 
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToMuProbeTrk"),                   histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToMuProbeTrkWithFilter"),         histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer, True)
+#  add_channels  (process,  getNLayersChannelVariations("ZtoTauToMuProbeTrkWithSSFilter"),       histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers + tauToMuonTPProducer, True)
+
 ################################################################################
 # Tau channels
 ################################################################################
 #  add_channels  (process,  [TauTagPt55NoJetCuts],         histSetsTau,  weights,  scaleFactorProducers,  collMap,  variableProducers,  False)
 #  add_channels  (process,  [TauTagPt55NoJetCutsMetTrig],  histSetsTau,  weights,  scaleFactorProducers,  collMap,  variableProducers,  False)
+#  add_channels  (process,  getNLayersChannelVariations("TauTagPt55NoJetCuts"),         histSetsTau,  weights,  scaleFactorProducers,  collMap,  variableProducers,  True)
+#  add_channels  (process,  getNLayersChannelVariations("TauTagPt55NoJetCutsMetTrig"),  histSetsTau,  weights,  scaleFactorProducers,  collMap,  variableProducers,  True)
+
+################################################################################
+# Fake tracks channels
+################################################################################
+#  add_channels  (process,  [ZtoMuMuDisTrkNoD0CutNLayers4],            histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers, True)
+#  add_channels  (process,  [ZtoMuMuDisTrkNoD0CutNLayers5],            histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers, True)
+#  add_channels  (process,  [ZtoMuMuDisTrkNoD0CutNLayers6plus],        histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers, True)
+#  add_channels  (process,  [ZtoMuMu],                        histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers, True)
+#  add_channels  (process,  [disTrkIdFakeNLayers4],             histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  [disTrkIdFakeNLayers5],             histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  [disTrkIdFakeNLayers6plus],             histSets,  weights,  [],  collMap,  variableProducers,  True)
+#  add_channels  (process,  [basicSelection],                histSets,  weights,  [],  collMap,  variableProducers,  True)
+
+################################################################################
+# Lepton SFs testing channels
+################################################################################
+#  add_channels  (process,  [ElectronTagSkim],  histSetsElectron,  weightsWithEleSF,  scaleFactorProducersWithElectrons,  collMap,  variableProducers, False)
+#  add_channels  (process,  [MuonTagSkim],  histSetsMuon,  weightsWithMuonSF,  scaleFactorProducersWithMuons,  collMap,  variableProducers, False)
 
 if hasattr(process, 'EventJetVarProducer'):
 	process.EventJetVarProducer.triggerNames = triggerNamesInclusive

--- a/StandardAnalysis/python/EventWeights.py
+++ b/StandardAnalysis/python/EventWeights.py
@@ -68,11 +68,11 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     muonIsoPayload = "muonIso2018TightTightID"
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
     print("# EventWeights applied: 2022")
-    electronRecoPayload = "electronReco2022"
-    electronIDPayload = "electronID2022Tight"
-    muonTriggerPayload = "muonTrigger2022IsoMu24"
-    muonIDPayload = "muonID2022Tight"
-    muonIsoPayload = "muonIso2022TightTightID"
+    electronRecoPayload = "electronReco2022EFG"
+    electronIDPayload = "electronID2022EFGTight"
+    muonTriggerPayload = "muonTrigger2022EFGIsoMu24"
+    muonIDPayload = "muonID2022EFGTight"
+    muonIsoPayload = "muonIso2022EFGTightTightID"
 else:
     print("# EventWeights applied: 2015")
     electronRecoPayload = "electronReco2015"

--- a/StandardAnalysis/python/HistogramDefinitions.py
+++ b/StandardAnalysis/python/HistogramDefinitions.py
@@ -135,6 +135,13 @@ TrackExtraHistograms = cms.PSet(
             inputVariables = cms.vstring("bestTrackMissingOuterHits", "caloNewNoPUDRp5CentralCalo"),
             ),
         cms.PSet (
+            name = cms.string("trackFitPlaneWithCaloJet"),
+            title = cms.string("Number of Missing Outer Hits;N_{miss}^{out};matchedCaloJetEmEnergy+matchedCaloJetHadEnergy [GeV]"),
+            binsX = cms.untracked.vdouble(16, -0.5, 15.5),
+            binsY = cms.untracked.vdouble(100, 0, 100),
+            inputVariables = cms.vstring("bestTrackMissingOuterHits", "matchedCaloJetEmEnergy + matchedCaloJetHadEnergy"),
+            ),
+        cms.PSet (
             name = cms.string("trackNHitsMissingOuter"),
             title = cms.string("Number of Missing Outer Hits;N_{miss}^{out}"),
             binsX = cms.untracked.vdouble(16, -0.5, 15.5),

--- a/StandardAnalysis/python/LeptonScaleFactors.py
+++ b/StandardAnalysis/python/LeptonScaleFactors.py
@@ -197,12 +197,12 @@ electronScaleFactors2022 = cms.VPSet (
     cms.PSet (
         inputCollection = cms.string("electrons"),
         sfType = cms.string("Reco"),
-        version = cms.string("2022"),
+        version = cms.string("2022EFG"),
     ),
     cms.PSet (
         inputCollection = cms.string("electrons"),
         sfType = cms.string("ID"),
-        version = cms.string("2022"),
+        version = cms.string("2022EFG"),
         wp = cms.string("Tight"),
     ),
 )
@@ -211,19 +211,54 @@ muonScaleFactors2022 = cms.VPSet (
     cms.PSet (
         inputCollection = cms.string("muons"),
         sfType = cms.string("Trigger"),
-        version = cms.string("2022"),
+        version = cms.string("2022EFG"),
         wp = cms.string("IsoMu24"),
     ),
     cms.PSet (
         inputCollection = cms.string("muons"),
         sfType = cms.string("ID"),
-        version = cms.string("2022"),
+        version = cms.string("2022EFG"),
         wp = cms.string("Tight"),
     ),
     cms.PSet (
         inputCollection = cms.string("muons"),
         sfType = cms.string("Iso"),
-        version = cms.string("2022"),
+        version = cms.string("2022EFG"),
+        wp = cms.string("TightTightID"),
+    ),
+)
+
+electronScaleFactors2023 = cms.VPSet (
+    cms.PSet (
+        inputCollection = cms.string("electrons"),
+        sfType = cms.string("Reco"),
+        version = cms.string("2023C"),
+    ),
+    cms.PSet (
+        inputCollection = cms.string("electrons"),
+        sfType = cms.string("ID"),
+        version = cms.string("2023C"),
+        wp = cms.string("Tight"),
+    ),
+)
+
+muonScaleFactors2023 = cms.VPSet (
+    cms.PSet (
+        inputCollection = cms.string("muons"),
+        sfType = cms.string("Trigger"),
+        version = cms.string("2023C"),
+        wp = cms.string("IsoMu24"),
+    ),
+    cms.PSet (
+        inputCollection = cms.string("muons"),
+        sfType = cms.string("ID"),
+        version = cms.string("2023C"),
+        wp = cms.string("Tight"),
+    ),
+    cms.PSet (
+        inputCollection = cms.string("muons"),
+        sfType = cms.string("Iso"),
+        version = cms.string("2023C"),
         wp = cms.string("TightTightID"),
     ),
 )
@@ -254,7 +289,7 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     ElectronScaleFactorProducer['scaleFactors'] = electronScaleFactors2018
     MuonScaleFactorProducer['scaleFactors'] = muonScaleFactors2018
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
-    print("# Lepton SFs: 2022")
+    print("# Lepton SFs: 2022 or 2023; Check the config and customize to know what is used")
     ElectronScaleFactorProducer['scaleFactors'] = electronScaleFactors2022
     MuonScaleFactorProducer['scaleFactors'] = muonScaleFactors2022
 else:

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -212,68 +212,12 @@ def customize (process,
 
         if runEra in ['C', 'D']:
 
-            strsOSUMuonProducer = []
-            strsOSUTrackProducer = []
-            strsPlotter = []
-            strsObjectScalingFactorProducer = []
+            changeMuonTriggerFilter(process,'HLT_IsoMu24_v','hltIterL3MuonCandidates::HLT','hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08')
 
-            # vars(process) is a dictionary that contain 28 categories: _Process__name, _Process__filters, _Process__producers, _Process__switchproducers,_Process__source, _Process__looper, _Process__subProcesses, _Process__schedule, _Process__analyzers, _Process__outputmodules, _Process__paths, _Process__endpaths, _Process__finalpaths, _Process__sequences, _Process__tasks, _Process__conditionaltasks, _Process__services, _Process__essources, _Process__esproducers, _Process__esprefers, _Process__aliases, _Process__psets, _Process__vpsets, _Process__InExtendCall, _Process__partialschedules, _Process__isStrict, _Process__modifiers, _Process__accelerators
-            # Each category contains the modules that fit in the given category. Not all of them have modules, or not all modules will be needed to be changed in this script (e.g., PoolSource)
+            if not realData:
 
-            attrs = (vars(process))['_Process__producers']
-
-            # After getting the modules of a given category in another dictionary with (vars(process))[nameOfCategory], it is possible to loop through the modules and find a specific one that needs to be customized depending on year/era
-
-            for key,value in attrs.items():
-
-                # _TypedParameterizable__type gets the name of the modules defined in the plugin .cc file, and key contain the instance of the module in the python config file. In this case the instances of OSUMuonProducer and OSUTrackProducer need to be changed per era in 2022. In configs with multiple channels, multiple copies of the same module will appear with distinct names for the distinct instances, which are saved in the lists strsOSUMuonProducer and strsOSUTrackProducer
-
-                if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strsOSUMuonProducer.append(key)
-                if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strsOSUTrackProducer.append(key)
-
-            # The list of modules obtained above can be looped through to find them inside the process with the hasattr function. To modify the module it is needed to get it with the getattr function and then changes can happen. In the particular of moduleOSUMuonProducer.hltMatchingInfo that is a cms.VPSet(), its elements can be looped through to apply modifications. These same steps are repeated in the following customizations
-
-            for strOSUMuonProducer in strsOSUMuonProducer:
-                if hasattr (process, strOSUMuonProducer):
-                    moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
-                    for x in moduleOSUMuonProducer.hltMatchingInfo:
-                        if x.name.value() == "HLT_IsoMu24_v":
-                            x.collection = cms.string("hltIterL3MuonCandidates::HLT")
-                            x.filter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
-            for strOSUTrackProducer in strsOSUTrackProducer:
-                if hasattr (process, strOSUTrackProducer):
-                    moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
-                    moduleOSUTrackProducer.muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
-
-            attrs = (vars(process))['_Process__filters']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
-            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
-                if hasattr (process, strObjectScalingFactorProducer):
-                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
-                    for x in moduleObjectScalingFactorProducer.scaleFactors:
-                        if x.inputCollection.value() == "electrons":
-                            x.version = cms.string("2022CD")
-                        if x.inputCollection.value() == "muons":
-                            x.version = cms.string("2022CD")
-
-            attrs = (vars(process))['_Process__analyzers']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
-            for strPlotter in strsPlotter:
-                if hasattr (process, strPlotter):
-                    modulePlotter = getattr(process, strPlotter)
-                    for x in modulePlotter.weights:
-                        if x.inputVariable.value() == "electronReco2022EFG":
-                            x.inputVariable = cms.string("electronReco2022CD")
-                        if x.inputVariable.value() == "electronID2022EFGTight":
-                            x.inputVariable = cms.string("electronID2022CDTight")
-                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
-                            x.inputVariable = cms.string("muonTrigger2022CDIsoMu24")
-                        if x.inputVariable.value() == "muonID2022EFGTight":
-                            x.inputVariable = cms.string("muonID2022CDTight")
-                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
-                            x.inputVariable = cms.string("muonIso2022CDTightTightID")
+                changeScaleFactorsRun3(process,'2022CD')
+                changeLeptonWeightsRun3(process,'2022CD')
 
         process.PUScalingFactorProducer.PU = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2022")
@@ -332,77 +276,20 @@ def customize (process,
 
         if runEra in ['C']:
 
-            strsPlotter = []
-            strsObjectScalingFactorProducer = []
+            if not realData:
 
-            attrs = (vars(process))['_Process__filters']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
-            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
-                if hasattr (process, strObjectScalingFactorProducer):
-                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
-                    for x in moduleObjectScalingFactorProducer.scaleFactors:
-                        if x.inputCollection.value() == "electrons":
-                            x.version = cms.string("2023C")
-                        if x.inputCollection.value() == "muons":
-                            x.version = cms.string("2023C")
+                changeScaleFactorsRun3(process,'2023C')
+                changeLeptonWeightsRun3(process,'2023C')
 
-            attrs = (vars(process))['_Process__analyzers']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
-            for strPlotter in strsPlotter:
-                if hasattr (process, strPlotter):
-                    modulePlotter = getattr(process, strPlotter)
-                    for x in modulePlotter.weights:
-                        if x.inputVariable.value() == "electronReco2022EFG":
-                            x.inputVariable = cms.string("electronReco2023C")
-                        if x.inputVariable.value() == "electronID2022EFGTight":
-                            x.inputVariable = cms.string("electronID2023CTight")
-                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
-                            x.inputVariable = cms.string("muonTrigger2023CIsoMu24")
-                        if x.inputVariable.value() == "muonID2022EFGTight":
-                            x.inputVariable = cms.string("muonID2023CTight")
-                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
-                            x.inputVariable = cms.string("muonIso2023CTightTightID")
-        
         if runEra in ['D']:
 
+            if not realData:
+
+                changeScaleFactorsRun3(process,'2023D',prefix='NoHole')
+                changeLeptonWeightsRun3(process,'2023D',prefix='NoHole')
+
             strsPlotter = []
             strsObjectScalingFactorProducer = []
-
-            attrs = (vars(process))['_Process__filters']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
-            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
-                if hasattr (process, strObjectScalingFactorProducer):
-                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
-                    for x in moduleObjectScalingFactorProducer.scaleFactors:
-                        if x.inputCollection.value() == "electrons" and x.sfType.value() == 'Reco':
-                            x.version = cms.string("2023D")
-                        if x.inputCollection.value() == "electrons" and x.sfType.value() == 'ID':
-                            x.version = cms.string('2023D')
-                            x.prefix = cms.string('NoHole')
-                        if x.inputCollection.value() == "muons":
-                            x.version = cms.string("2023D")
-
-            attrs = (vars(process))['_Process__analyzers']
-            for key,value in attrs.items():
-                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
-            for strPlotter in strsPlotter:
-                if hasattr (process, strPlotter):
-                    modulePlotter = getattr(process, strPlotter)
-                    for x in modulePlotter.weights:
-                        if x.inputVariable.value() == "electronReco2022EFG":
-                            x.inputVariable = cms.string("electronReco2023D")
-                        if x.inputVariable.value() == "electronID2022EFGTight":
-                            x.inputVariable = cms.string("NoHoleElectronID2023DTight")
-                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
-                            x.inputVariable = cms.string("muonTrigger2023DIsoMu24")
-                        if x.inputVariable.value() == "muonID2022EFGTight":
-                            x.inputVariable = cms.string("muonID2023DTight")
-                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
-                            x.inputVariable = cms.string("muonIso2023DTightTightID")
-        
 
         process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2023")

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -211,12 +211,28 @@ def customize (process,
             mc_global_tag = '130X_mcRun3_2022_realistic_postEE_v6'
 
         if runEra in ['C', 'D']:
+
             strsOSUMuonProducer = []
             strsOSUTrackProducer = []
+            strsPlotter = []
+            strsObjectScalingFactorProducer = []
+
+            # vars(process) is a dictionary that contain 28 categories: _Process__name, _Process__filters, _Process__producers, _Process__switchproducers,_Process__source, _Process__looper, _Process__subProcesses, _Process__schedule, _Process__analyzers, _Process__outputmodules, _Process__paths, _Process__endpaths, _Process__finalpaths, _Process__sequences, _Process__tasks, _Process__conditionaltasks, _Process__services, _Process__essources, _Process__esproducers, _Process__esprefers, _Process__aliases, _Process__psets, _Process__vpsets, _Process__InExtendCall, _Process__partialschedules, _Process__isStrict, _Process__modifiers, _Process__accelerators
+            # Each category contains the modules that fit in the given category. Not all of them have modules, or not all modules will be needed to be changed in this script (e.g., PoolSource)
+
             attrs = (vars(process))['_Process__producers']
+
+            # After getting the modules of a given category in another dictionary with (vars(process))[nameOfCategory], it is possible to loop through the modules and find a specific one that needs to be customized depending on year/era
+
             for key,value in attrs.items():
+
+                # _TypedParameterizable__type gets the name of the modules defined in the plugin .cc file, and key contain the instance of the module in the python config file. In this case the instances of OSUMuonProducer and OSUTrackProducer need to be changed per era in 2022. In configs with multiple channels, multiple copies of the same module will appear with distinct names for the distinct instances, which are saved in the lists strsOSUMuonProducer and strsOSUTrackProducer
+
                 if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strsOSUMuonProducer.append(key)
                 if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strsOSUTrackProducer.append(key)
+
+            # The list of modules obtained above can be looped through to find them inside the process with the hasattr function. To modify the module it is needed to get it with the getattr function and then changes can happen. In the particular of moduleOSUMuonProducer.hltMatchingInfo that is a cms.VPSet(), its elements can be looped through to apply modifications. These same steps are repeated in the following customizations
+
             for strOSUMuonProducer in strsOSUMuonProducer:
                 if hasattr (process, strOSUMuonProducer):
                     moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
@@ -228,7 +244,37 @@ def customize (process,
                 if hasattr (process, strOSUTrackProducer):
                     moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
                     moduleOSUTrackProducer.muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08")
-        
+
+            attrs = (vars(process))['_Process__filters']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
+            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
+                if hasattr (process, strObjectScalingFactorProducer):
+                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
+                    for x in moduleObjectScalingFactorProducer.scaleFactors:
+                        if x.inputCollection.value() == "electrons":
+                            x.version = cms.string("2022CD")
+                        if x.inputCollection.value() == "muons":
+                            x.version = cms.string("2022CD")
+
+            attrs = (vars(process))['_Process__analyzers']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
+            for strPlotter in strsPlotter:
+                if hasattr (process, strPlotter):
+                    modulePlotter = getattr(process, strPlotter)
+                    for x in modulePlotter.weights:
+                        if x.inputVariable.value() == "electronReco2022EFG":
+                            x.inputVariable = cms.string("electronReco2022CD")
+                        if x.inputVariable.value() == "electronID2022EFGTight":
+                            x.inputVariable = cms.string("electronID2022CDTight")
+                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
+                            x.inputVariable = cms.string("muonTrigger2022CDIsoMu24")
+                        if x.inputVariable.value() == "muonID2022EFGTight":
+                            x.inputVariable = cms.string("muonID2022CDTight")
+                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
+                            x.inputVariable = cms.string("muonIso2022CDTightTightID")
+
         process.PUScalingFactorProducer.PU = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2022")
         process.PUScalingFactorProducer.targetUp = cms.string ("data2022Up")
@@ -283,6 +329,80 @@ def customize (process,
             mc_global_tag = '130X_mcRun3_2023_realistic_v14'
         elif runEra in ['D']:
             mc_global_tag = '130X_mcRun3_2023_realistic_postBPix_v2'
+
+        if runEra in ['C']:
+
+            strsPlotter = []
+            strsObjectScalingFactorProducer = []
+
+            attrs = (vars(process))['_Process__filters']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
+            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
+                if hasattr (process, strObjectScalingFactorProducer):
+                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
+                    for x in moduleObjectScalingFactorProducer.scaleFactors:
+                        if x.inputCollection.value() == "electrons":
+                            x.version = cms.string("2023C")
+                        if x.inputCollection.value() == "muons":
+                            x.version = cms.string("2023C")
+
+            attrs = (vars(process))['_Process__analyzers']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
+            for strPlotter in strsPlotter:
+                if hasattr (process, strPlotter):
+                    modulePlotter = getattr(process, strPlotter)
+                    for x in modulePlotter.weights:
+                        if x.inputVariable.value() == "electronReco2022EFG":
+                            x.inputVariable = cms.string("electronReco2023C")
+                        if x.inputVariable.value() == "electronID2022EFGTight":
+                            x.inputVariable = cms.string("electronID2023CTight")
+                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
+                            x.inputVariable = cms.string("muonTrigger2023CIsoMu24")
+                        if x.inputVariable.value() == "muonID2022EFGTight":
+                            x.inputVariable = cms.string("muonID2023CTight")
+                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
+                            x.inputVariable = cms.string("muonIso2023CTightTightID")
+        
+        if runEra in ['D']:
+
+            strsPlotter = []
+            strsObjectScalingFactorProducer = []
+
+            attrs = (vars(process))['_Process__filters']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
+            for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
+                if hasattr (process, strObjectScalingFactorProducer):
+                    moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
+                    for x in moduleObjectScalingFactorProducer.scaleFactors:
+                        if x.inputCollection.value() == "electrons" and x.sfType.value() == 'Reco':
+                            x.version = cms.string("2023D")
+                        if x.inputCollection.value() == "electrons" and x.sfType.value() == 'ID':
+                            x.version = cms.string('2023D')
+                            x.prefix = cms.string('NoHole')
+                        if x.inputCollection.value() == "muons":
+                            x.version = cms.string("2023D")
+
+            attrs = (vars(process))['_Process__analyzers']
+            for key,value in attrs.items():
+                if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
+            for strPlotter in strsPlotter:
+                if hasattr (process, strPlotter):
+                    modulePlotter = getattr(process, strPlotter)
+                    for x in modulePlotter.weights:
+                        if x.inputVariable.value() == "electronReco2022EFG":
+                            x.inputVariable = cms.string("electronReco2023D")
+                        if x.inputVariable.value() == "electronID2022EFGTight":
+                            x.inputVariable = cms.string("NoHoleElectronID2023DTight")
+                        if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
+                            x.inputVariable = cms.string("muonTrigger2023DIsoMu24")
+                        if x.inputVariable.value() == "muonID2022EFGTight":
+                            x.inputVariable = cms.string("muonID2023DTight")
+                        if x.inputVariable.value() == "muonIso2022EFGTightTightID":
+                            x.inputVariable = cms.string("muonIso2023DTightTightID")
+        
 
         process.PUScalingFactorProducer.PU     = cms.FileInPath ('DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root')
         process.PUScalingFactorProducer.target = cms.string ("data2023")

--- a/StandardAnalysis/python/miniAOD_124X_Samples.py
+++ b/StandardAnalysis/python/miniAOD_124X_Samples.py
@@ -108,7 +108,7 @@ dataset_names_bkgd = {
 
     'WToLNu_4Jets_2022EE' : '/WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
 
-    'DYto2L_4jets_M10to50_2022EE' : '',
+    'DYto2L_4jets_M10to50_2022EE' : '/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/borzari-Skimming-961090dd68da90db16dc3ce116f1abf9/USER',
     'DYJetsToLL_M50_2022EE' : '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/borzari-3Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
 
     'TbarBtoLminusNuB_2022EE' : '/TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
@@ -151,7 +151,104 @@ dataset_names_bkgd = {
     'Zto2Nu_4Jets_HT1500to2500_2022EE' : '/Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
     'Zto2Nu_4Jets_HT2500_2022EE' : '/Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/borzari-Skimming_2022EE-3a8953c6b719d6563fe908b4ea7a6705/USER',
 
-    'DYJetsToLL_M50_merged' : '/abyss/users/mcarrigan/DYJetsToLL_M-50-merged/',
+    # 'DYJetsToLL_M50_merged' : '/abyss/users/mcarrigan/DYJetsToLL_M-50-merged/',
+
+}
+
+# Put in the order they are in https://docs.google.com/spreadsheets/d/19JS0zfIoQxH8sVOvsY1mg-Ct1Aw80Fm0TCgxewafGp8/edit?gid=371784835#gid=371784835
+dataset_names_bkgd_MiniAOD = {
+
+    'DYto2L_4jets_M10to50_2022EE' : '/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM',
+    'DYJetsToLL_M50_2022EE' : '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-forPOG_130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+
+    'TbarBtoLminusNuB_2022EE' : '/TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TBbartoLplusNuBbar_2022EE' : '/TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TbarQtoLNu_2022EE' : '/TbarQtoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TQbartoLNu_2022EE' : '/TQbartoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TbarWplusto2L2Nu_2022EE' : '/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'TbarWplustoLNu2Q_2022EE' : '/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'TWminusto2L2Nu_2022EE' : '/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'TWminustoLNu2Q_2022EE' : '/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+
+    'TTto2L2Nu_2022EE' : '/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TTtoLNu2Q_2022EE' : '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'TTto4Q_2022EE' : '/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+
+    'WW_2022EE' : '/WW_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'WZ_2022EE' : '/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'ZZ_2022EE' : '/ZZ_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+
+    'WToLNu_4Jets_2022EE' : '/WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+
+    'Zto2Nu_4Jets_HT100to200_2022EE' : '/Zto2Nu-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT200to400_2022EE' : '/Zto2Nu-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT400to800_2022EE' : '/Zto2Nu-4Jets_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT800to1500_2022EE' : '/Zto2Nu-4Jets_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM',
+    'Zto2Nu_4Jets_HT1500to2500_2022EE' : '/Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT2500_2022EE' : '/Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+
+    'QCD_PT15to30_2022EE' : '/QCD_PT-15to30_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-EpsilonPU_130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'QCD_PT30to50_2022EE' : '/QCD_PT-30to50_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-EpsilonPU_130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'QCD_PT50to80_2022EE' : '/QCD_PT-50to80_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'QCD_PT80to120_2022EE' : '/QCD_PT-80to120_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM',
+    'QCD_PT120to170_2022EE' : '/QCD_PT-120to170_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT170to300_2022EE' : '/QCD_PT-170to300_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT300to470_2022EE' : '/QCD_PT-300to470_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT470to600_2022EE' : '/QCD_PT-470to600_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT600to800_2022EE' : '/QCD_PT-600to800_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT800to1000_2022EE' : '/QCD_PT-800to1000_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT1000to1400_2022EE' : '/QCD_PT-1000to1400_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT1400to1800_2022EE' : '/QCD_PT-1400to1800_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT1800to2400_2022EE' : '/QCD_PT-1800to2400_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT2400to3200_2022EE' : '/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+    'QCD_PT3200_2022EE' : '/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM',
+
+
+
+    'DYto2L_4jets_M10to50_2022' : '/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM',
+    'DYJetsToLL_M50_2022' : '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22MiniAODv4-forPOG_130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'TbarBtoLminusNuB_2022' : '/TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TBbartoLplusNuBbar_2022' : '/TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TbarQtoLNu_2022' : '/TbarQtoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TQbartoLNu_2022' : '/TQbartoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TbarWplusto2L2Nu_2022' : '/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TbarWplustoLNu2Q_2022' : '/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TWminusto2L2Nu_2022' : '/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TWminustoLNu2Q_2022' : '/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'TTto2L2Nu_2022' : '/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TTtoLNu2Q_2022' : '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'TTto4Q_2022' : '/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'WW_2022' : '/WW_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'WZ_2022' : '/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'ZZ_2022' : '/ZZ_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'WToLNu_4Jets_2022' : '/WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'Zto2Nu_4Jets_HT100to200_2022' : '/Zto2Nu-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT200to400_2022' : '/Zto2Nu-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT400to800_2022' : '/Zto2Nu-4Jets_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT800to1500_2022' : '/Zto2Nu-4Jets_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT1500to2500_2022' : '/Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT2500_2022' : '/Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM',
+
+    'QCD_PT15to30_2022' : '/QCD_PT-15to30_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT30to50_2022' : '/QCD_PT-30to50_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-EpsilonPU_130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT50to80_2022' : '/QCD_PT-50to80_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT80to120_2022' : '/QCD_PT-80to120_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT120to170_2022' : '/QCD_PT-120to170_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT170to300_2022' : '/QCD_PT-170to300_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT300to470_2022' : '/QCD_PT-300to470_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT470to600_2022' : '/QCD_PT-470to600_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT600to800_2022' : '/QCD_PT-600to800_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT800to1000_2022' : '/QCD_PT-800to1000_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT1000to1400_2022' : '/QCD_PT-1000to1400_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT1400to1800_2022' : '/QCD_PT-1400to1800_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT1800to2400_2022' : '/QCD_PT-1800to2400_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT2400to3200_2022' : '/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
+    'QCD_PT3200_2022' : '/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
 
 }
 

--- a/StandardAnalysis/python/utilities.py
+++ b/StandardAnalysis/python/utilities.py
@@ -351,3 +351,71 @@ def createChannelVariations (channel, channelName, cutToReplace, replacements):
         else:
             replaceSingleCut (newChannels[channelName + suffix].cuts, replacements[suffix], cutToReplace)
     return newChannels
+
+def changeMuonTriggerFilter(process, path, collection, filter):
+    strsOSUMuonProducer = []
+    strsOSUTrackProducer = []
+
+    # vars(process) is a dictionary that contain 28 categories: _Process__name, _Process__filters, _Process__producers, _Process__switchproducers,_Process__source, _Process__looper, _Process__subProcesses, _Process__schedule, _Process__analyzers, _Process__outputmodules, _Process__paths, _Process__endpaths, _Process__finalpaths, _Process__sequences, _Process__tasks, _Process__conditionaltasks, _Process__services, _Process__essources, _Process__esproducers, _Process__esprefers, _Process__aliases, _Process__psets, _Process__vpsets, _Process__InExtendCall, _Process__partialschedules, _Process__isStrict, _Process__modifiers, _Process__accelerators
+    # Each category contains the modules that fit in the given category. Not all of them have modules, or not all modules will be needed to be changed in this script (e.g., PoolSource)
+
+    attrs = (vars(process))['_Process__producers']
+
+    # After getting the modules of a given category in another dictionary with (vars(process))[nameOfCategory], it is possible to loop through the modules and find a specific one that needs to be customized depending on year/era
+
+    for key,value in attrs.items():
+
+        # _TypedParameterizable__type gets the name of the modules defined in the plugin .cc file, and key contain the instance of the module in the python config file. In this case the instances of OSUMuonProducer and OSUTrackProducer need to be changed per era in 2022. In configs with multiple channels, multiple copies of the same module will appear with distinct names for the distinct instances, which are saved in the lists strsOSUMuonProducer and strsOSUTrackProducer
+
+        if (vars(value))['_TypedParameterizable__type'] == 'OSUMuonProducer': strsOSUMuonProducer.append(key)
+        if (vars(value))['_TypedParameterizable__type'] == 'OSUTrackProducer': strsOSUTrackProducer.append(key)
+
+    # The list of modules obtained above can be looped through to find them inside the process with the hasattr function. To modify the module it is needed to get it with the getattr function and then changes can happen. In the particular of moduleOSUMuonProducer.hltMatchingInfo that is a cms.VPSet(), its elements can be looped through to apply modifications. These same steps are repeated in functions changeScaleFactorsRun3 and changeLeptonWeightsRun3
+
+    for strOSUMuonProducer in strsOSUMuonProducer:
+        if hasattr (process, strOSUMuonProducer):
+            moduleOSUMuonProducer = getattr(process, strOSUMuonProducer)
+            for x in moduleOSUMuonProducer.hltMatchingInfo:
+                if x.name.value() == path:
+                    x.collection = cms.string(collection)
+                    x.filter = cms.string(filter)
+    for strOSUTrackProducer in strsOSUTrackProducer:
+        if hasattr (process, strOSUTrackProducer):
+            moduleOSUTrackProducer = getattr(process, strOSUTrackProducer)
+            moduleOSUTrackProducer.muonTriggerFilter = cms.string(filter)
+
+def changeScaleFactorsRun3(process, version, prefix=''):
+    strsObjectScalingFactorProducer = []
+    attrs = (vars(process))['_Process__filters']
+    for key,value in attrs.items():
+        if (vars(value))['_TypedParameterizable__type'] == 'ObjectScalingFactorProducer': strsObjectScalingFactorProducer.append(key)
+    for strObjectScalingFactorProducer in strsObjectScalingFactorProducer:
+        if hasattr (process, strObjectScalingFactorProducer):
+            moduleObjectScalingFactorProducer = getattr(process, strObjectScalingFactorProducer)
+            for x in moduleObjectScalingFactorProducer.scaleFactors:
+                if x.inputCollection.value() == "electrons":
+                    x.version = cms.string(version)
+                    if prefix != '' and x.sfType.value() == 'ID': x.prefix = cms.string(prefix)
+                if x.inputCollection.value() == "muons":
+                    x.version = cms.string(version)
+
+def changeLeptonWeightsRun3(process, version, prefix=''):
+    strsPlotter = []
+    attrs = (vars(process))['_Process__analyzers']
+    for key,value in attrs.items():
+        if (vars(value))['_TypedParameterizable__type'] == 'Plotter': strsPlotter.append(key)
+    for strPlotter in strsPlotter:
+        if hasattr (process, strPlotter):
+            modulePlotter = getattr(process, strPlotter)
+            for x in modulePlotter.weights:
+                if x.inputVariable.value() == "electronReco2022EFG":
+                    x.inputVariable = cms.string("electronReco" + version)
+                if x.inputVariable.value() == "electronID2022EFGTight":
+                    if prefix == '': x.inputVariable = cms.string("electronID" + version + "Tight")
+                    else: x.inputVariable = cms.string(prefix + "ElectronID" + version + "Tight")
+                if x.inputVariable.value() == "muonTrigger2022EFGIsoMu24":
+                    x.inputVariable = cms.string("muonTrigger" + version + "IsoMu24")
+                if x.inputVariable.value() == "muonID2022EFGTight":
+                    x.inputVariable = cms.string("muonID" + version + "Tight")
+                if x.inputVariable.value() == "muonIso2022EFGTightTightID":
+                    x.inputVariable = cms.string("muonIso" + version + "TightTightID")


### PR DESCRIPTION
This PR adds the needed changes for the 2023 lepton SFs to be applied over MC. For 2023C and 2023D there are distinct SFs and, in 2023D, there are also different sets to be used depending on the electron eta and phi. Tested all the cases: 2022CD, 2022EFG, 2023C and 2023D, and things seem to work fine.

Has to be merged together with https://github.com/OSU-CMS/OSUT3Analysis/pull/268.