### PR TITLE
Adding changes for 130X

### DIFF
--- a/SignalSystematics/test/config_2022_cfg.py
+++ b/SignalSystematics/test/config_2022_cfg.py
@@ -7,6 +7,11 @@ if not os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") and not os.environ
     sys.exit (0)
 
 options = VarParsing ('analysis')
+options.register ('doLifetimeReweighting',
+              False,
+              VarParsing.multiplicity.singleton,
+              VarParsing.varType.bool,
+              "turn on For LifetimeReweighting")
 options.register ('massForLifetimeReweighting',
               1000,
               VarParsing.multiplicity.singleton,
@@ -21,8 +26,8 @@ options.parseArguments()
 
 process = customize (process, "2022", "F", realData=True, applyPUReweighting = True, applyISRReweighting = True, applyTriggerReweighting = True, applyMissingHitsCorrections = True, runMETFilters = False)
 
-if hasattr(process, 'LifetimeWeightProducer'):
-    if options.isCRAB:
+if options.doLifetimeReweighting:
+    if hasattr(process, 'LifetimeWeightProducer'):
         exec('from OSUT3Analysis.Configuration.configurationOptions import *')
         rules = []
         rules.extend(rulesForLifetimeReweighting['AMSB_chargino_' + str(options.massForLifetimeReweighting) + 'GeV_' + str(options.lifetimeForLifetimeReweighting) + 'cm_130X'])

--- a/SignalSystematics/test/crab_SigSyst.py
+++ b/SignalSystematics/test/crab_SigSyst.py
@@ -13,8 +13,6 @@ config.General.requestName = 'DY_ZToMuMuISR' # this is the name of the crab fold
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'config_2022_cfg.py'
 config.JobType.allowUndistributedCMSSW = True
-# List of files that are in the repos, but are used for the selections
-config.JobType.inputFiles = [os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/electronSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/muonSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt', os.environ['CMSSW_BASE']+'/src/DisappTrks/StandardAnalysis/data/Summer22EE_23Sep2023_RunEFG_v1.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/graph.pb', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/graph_oct25.pb']
 
 # always use MINIAOD as inputDataset and AOD as secondaryInputDataset
 

--- a/SignalSystematics/test/crab_SignalYield.py
+++ b/SignalSystematics/test/crab_SignalYield.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
                 if mass == 100 and ctau == 10: # AMSB_Wino_100GeV_10cm original dataset only has 10k events; ext was created to fix it and has ~50k events
                     config.Data.inputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM' % (mass, ctau)
                     config.Data.secondaryInputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEDRPremix-124X_mcRun3_2022_realistic_postEE_v1_ext1-v2/AODSIM' % (mass, ctau)
-                config.JobType.pyCfgParams=["isCRAB=True","massForLifetimeReweighting="+str(mass),"lifetimeForLifetimeReweighting="+str(ctau)]
+                config.JobType.pyCfgParams=["doLifetimeReweighting=True","massForLifetimeReweighting="+str(mass),"lifetimeForLifetimeReweighting="+str(ctau)]
                 if reallySubmitMass[mass] and reallySubmitLifetime[ctau]:
                     forkAndSubmit(config)
                 else:

--- a/SignalSystematics/test/crab_SignalYield.py
+++ b/SignalSystematics/test/crab_SignalYield.py
@@ -12,7 +12,6 @@ config.General.transferLogs = True
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'config_2022_cfg.py'
 config.JobType.allowUndistributedCMSSW = True
-config.JobType.inputFiles = [os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/electronSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/AnaTools/data/muonSFs.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Configuration/data/Summer22EE_23Sep2023_RunEFG_v1.root', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/graph_oct25.pb', os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/graph.pb', os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/pu_disappTrks_run3.root', os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/triggerEfficiencies_disappTrks_run3.root', os.environ['CMSSW_BASE'] + '/src/DisappTrks/StandardAnalysis/data/isrWeight_disappTrks_run2.root']
 config.JobType.maxMemoryMB = 4000
 
 config.Data.inputDataset = ''


### PR DESCRIPTION
Removed the `isCRAB` option from the SignalSystematics config and included the more readable `doLifetimeReweighting`. Also updated the CRAB submission files with this change and removed the `inputFiles` list that isn't needed anymore.

Has to be merged together with https://github.com/OSU-CMS/OSUT3Analysis/pull/269.