### PR TITLE
Remove Era-By-Era Option

### DIFF
--- a/BackgroundEstimation/test/bkgdEstimate_2018.py
+++ b/BackgroundEstimation/test/bkgdEstimate_2018.py
@@ -13,7 +13,7 @@ dirs = getUser()
 canvas = TCanvas("c1", "c1",800,800)
 setCanvasStyle(canvas)
 
-background = "ELECTRON"
+background = "FAKE"
 if len(sys.argv) > 1:
     background = sys.argv[1]
 background = background.upper()
@@ -57,8 +57,11 @@ for runPeriod in runPeriods:
             print("--------------------------------------------------------------------------------")
 
             fout = TFile.Open("fakeTrackBkgdEstimate_zToMuMu_2018" + runPeriod + "_" + nLayersWord + ".root", "recreate")
-
-            fakeTrackBkgdEstimate = FakeTrackBkgdEstimate ()
+            txtFile = "fakeTrackBkgdEstimate_zToMuMu_2018" + runPeriod + "_" + nLayersWord + '.txt'
+            f = open(txtFile, 'w+')
+            f.close()
+            fakeTrackBkgdEstimate = FakeTrackBkgdEstimate ()            
+            fakeTrackBkgdEstimate.addTxtFile(txtFile)
             fakeTrackBkgdEstimate.addTFile (fout)
             fakeTrackBkgdEstimate.addLuminosityInInvPb (lumi["MET_2018" + runPeriod])
             fakeTrackBkgdEstimate.addChannel("Basic3hits",     "ZtoMuMuDisTrkNoD0CutNLayers4",       "SingleMu_2018" + runPeriod, dirs['Mike'] + "bfrancisStore/2018/fromLPC/fakeBackground")
@@ -97,8 +100,11 @@ for runPeriod in runPeriods:
             print("--------------------------------------------------------------------------------")
 
             fout = TFile.Open("fakeTrackBkgdEstimate_zToEE_2018" + runPeriod + "_" + nLayersWord + ".root", "recreate")
-
+            txtFile = "fakeTrackBkgdEstimate_zToEE_2018" + runPeriod + "_" + nLayersWord + '.txt'
+            f = open(txtFile, 'w+')
+            f.close()
             fakeTrackBkgdEstimate = FakeTrackBkgdEstimate ()
+            fakeTrackBkgdEstimate.addTxtFile(txtFile)
             fakeTrackBkgdEstimate.addTFile (fout)
             fakeTrackBkgdEstimate.addLuminosityInInvPb (lumi["MET_2018" + runPeriod])
             # durp

--- a/BackgroundSystematics/test/fakeTrackEstimateVsD0.py
+++ b/BackgroundSystematics/test/fakeTrackEstimateVsD0.py
@@ -9,23 +9,23 @@ from ROOT import gROOT, TFile, TGraphAsymmErrors
 gROOT.SetBatch () # I am Groot.
 
 if len (sys.argv) < 2:
-    print "Usage: " + os.path.basename (sys.argv[0]) + " NLAYERS"
+    print("Usage: " + os.path.basename (sys.argv[0]) + " NLAYERS")
     sys.exit (1)
 nLayers = sys.argv[1]
-if int (nLayers) > 5:
-    nLayers += "plus"
+#if int (nLayers) > 5:
+#    nLayers += "plus"
 
 dirs = getUser()
 
-runPeriods = ['']
+runPeriods = ['AB']
 
 stdout = sys.stdout
 nullout = open ("/dev/null", "w")
 sys.stdout = nullout
 
-N = 5
+N = 9
 A = 0.05
-B = 0.1
+B = 0.5
 D = (B - A) / N
 
 try:
@@ -46,18 +46,36 @@ for runPeriod in runPeriods:
         minD0 = A + i * D
 
         sys.stdout = stdout
-        print "minimum |d0|: " + str (minD0) + " cm"
+        print("minimum |d0|: " + str (minD0) + " cm")
+        print("maximum |d0|: " + str (minD0+0.05) + " cm")
+
         sys.stdout = nullout
 
+        fout = TFile.Open("fakeTrackBkgdEstimate_zToMuMu_2018" + runPeriod + "_" + nLayers + "Test.root", "recreate")
+        txtFile = "fakeTrackBkgdEstimate_zToMuMu_2018" + runPeriod + "_" + nLayers + 'Test.txt'
+        f = open(txtFile, 'w+')
         fakeTrackBkgdEstimate = FakeTrackBkgdEstimate ()
-        fakeTrackBkgdEstimate.addLuminosityInInvPb (lumi["MET_2017" + runPeriod])
+        fakeTrackBkgdEstimate.addLuminosityInInvPb (lumi["MET_2018" + runPeriod])
         fakeTrackBkgdEstimate.addMinD0 (minD0)
-        fakeTrackBkgdEstimate.addChannel  ("Basic3hits",      "ZtoMuMuDisTrkNoD0Cut3Layers",          "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/fakeTrackBackground")
-        fakeTrackBkgdEstimate.addChannel  ("DisTrkInvertD0",  "ZtoMuMuDisTrkNoD0CutNLayers"+nLayers,  "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/fakeTrackBackground_noD0")
-        fakeTrackBkgdEstimate.addChannel  ("Basic",           "BasicSelection",                       "MET_2017"       +  runPeriod,  dirs['Andrew']+"2017/basicSelection")
-        fakeTrackBkgdEstimate.addChannel  ("ZtoLL",           "ZtoMuMu",                              "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/zToMuMu")
+        fakeTrackBkgdEstimate.addMaxD0 (minD0+0.05)        
+        fakeTrackBkgdEstimate.addTFile (fout)
+        fakeTrackBkgdEstimate.addTxtFile(txtFile)
 
-        nEst = fakeTrackBkgdEstimate.printNest ()
+        #fakeTrackBkgdEstimate.addChannel  ("Basic3hits",      "ZtoMuMuDisTrkNoD0Cut3Layers",          "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/fakeTrackBackground")
+        #fakeTrackBkgdEstimate.addChannel  ("DisTrkInvertD0",  "ZtoMuMuDisTrkNoD0CutNLayers"+nLayers,  "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/fakeTrackBackground_noD0")
+        #fakeTrackBkgdEstimate.addChannel  ("Basic",           "BasicSelection",                       "MET_2017"       +  runPeriod,  dirs['Andrew']+"2017/basicSelection")
+        #fakeTrackBkgdEstimate.addChannel  ("ZtoLL",           "ZtoMuMu",                              "SingleMu_2017"  +  runPeriod,  dirs['Andrew']+"2017/zToMuMu")
+        fakeTrackBkgdEstimate.addChannel("Basic3hits",     "ZtoMuMuDisTrkNoD0CutNLayers4",       "SingleMu_2018" + runPeriod, dirs['Mike'] + "bfrancisStore/2018/fromLPC/fakeBackground")
+        fakeTrackBkgdEstimate.addChannel("DisTrkInvertD0", "ZtoMuMuDisTrkNoD0Cut" + nLayers, "SingleMu_2018" + runPeriod, dirs['Mike'] + "bfrancisStore/2018/fromLPC/fakeBackground")
+        fakeTrackBkgdEstimate.addChannel("Basic",          "BasicSelection",                     "MET_2018"      + runPeriod, dirs['Mike'] + "bfrancisStore/2018/fromLPC/basicSelection_v2")
+        fakeTrackBkgdEstimate.addChannel("ZtoLL",          "ZtoMuMu",                            "SingleMu_2018" + runPeriod, dirs['Mike'] + "bfrancisStore/2018/fromLPC/zToMuMu")
+
+        nEst = fakeTrackBkgdEstimate.printNest ()[0]
+
+
+        print("debugging!!!!")
+
+        print("nest", nEst, type(nEst))
 
         g0.SetPoint (i, minD0, nEst.centralValue ())
         g0.SetPointError (i, D / 2.0, D / 2.0, min (nEst.maxUncertainty (), nEst.centralValue ()), nEst.maxUncertainty ())
@@ -71,7 +89,7 @@ for runPeriod in runPeriods:
             maxFluctuationUp = max (maxFluctuationUp, nEst.centralValue () - nominal)
 
     sys.stdout = stdout
-    print "[2017" + runPeriod + "] systematic uncertainty: - " + str (maxFluctuationDown) + " + " + str (maxFluctuationUp) + " (- " + str ((maxFluctuationDown / nominal) * 100.0) + " + " + str ((maxFluctuationUp / nominal) * 100.0) + ")%"
+    print ("[2017" + runPeriod + "] systematic uncertainty: - " + str (maxFluctuationDown) + " + " + str (maxFluctuationUp) + " (- " + str ((maxFluctuationDown / nominal) * 100.0) + " + " + str ((maxFluctuationUp / nominal) * 100.0) + ")%")
     sys.stdout = nullout
 
     fout = TFile ("fakeTrackEstimateVsD0.root", "update")

--- a/StandardAnalysis/python/customize.py
+++ b/StandardAnalysis/python/customize.py
@@ -263,7 +263,7 @@ def customize (process,
             setFiducialMaps (process, electrons="OSUT3Analysis/Configuration/data/electronFiducialMap_2022F_data.root", muons="OSUT3Analysis/Configuration/data/muonFiducialMap_2022F_data.root")
 
         setThresholdForFiducialMapVeto (process, 2.0)
-        setUseEraByEraFiducialMaps (process, True)
+        setUseEraByEraFiducialMaps (process, False)
         setMissingHitsCorrection (process, "2022EFG")
 
     elif runPeriod == "2023":
@@ -326,7 +326,7 @@ def customize (process,
             print("There is no jet veto map set up for this era, please add it to OSUT3Analysis/Configuration/data/")
             setFiducialMaps (process, electrons="OSUT3Analysis/Configuration/data/electronFiducialMap_2023C_data.root", muons="OSUT3Analysis/Configuration/data/muonFiducialMap_2022F_data.root")
         setThresholdForFiducialMapVeto (process, 2.0)
-        setUseEraByEraFiducialMaps (process, True)
+        setUseEraByEraFiducialMaps (process, False)
         
         setMissingHitsCorrection (process, "uncorrected")
 

--- a/StandardAnalysis/scripts/findMissingMiddleHitsCorrection.py
+++ b/StandardAnalysis/scripts/findMissingMiddleHitsCorrection.py
@@ -8,7 +8,7 @@ import numpy
 import random
 import re
 import copy
-
+from DisappTrks.StandardAnalysis.IntegratedLuminosity_cff import lumi
 ################################################################################
 # The following are parameters that you might want to edit.
 ################################################################################
@@ -38,6 +38,10 @@ mc.SetDirectory (0)
 data = dataFile.Get ("HitsSystematicsCtrlSelectionPlotter/Track Plots/trackNHitsMissingMiddle")
 data.SetName ("data")
 data.SetDirectory (0)
+
+#current missing hits data is scaled to 2022F, so scale from there to any other era
+scale = lumi['MET_2022EFG']/lumi['MET_2022F']
+mc.Scale(scale)
 
 mcFile.Close ()
 dataFile.Close ()

--- a/StandardAnalysis/scripts/findMissingOuterHitsCorrection.py
+++ b/StandardAnalysis/scripts/findMissingOuterHitsCorrection.py
@@ -8,7 +8,7 @@ import numpy
 import random
 import re
 import copy
-
+from DisappTrks.StandardAnalysis.IntegratedLuminosity_cff import lumi
 ################################################################################
 # The following are parameters that you might want to edit.
 ################################################################################
@@ -47,6 +47,10 @@ mc.SetDirectory (0)
 data = dataFile.Get ("MuonCtrlSelectionPlotter/Track Plots/trackNHitsMissingOuter")
 data.SetName ("data")
 data.SetDirectory (0)
+
+#current missing hits data is scaled to 2022F, so scale from there to any other era
+scale = lumi['MET_2022EFG']/lumi['MET_2022F']
+mc.Scale(scale)
 
 mcFile.Close ()
 dataFile.Close ()


### PR DESCRIPTION
remove the set fiducial maps era-by-era option (set to false in customize)

small bug fixes to run fake tracks estimate on 2018 data

bug fixes to run fake tracks validation studies