### PR TITLE
Updating CRAB config files

### DIFF
--- a/ClosureTests/test/crab_ClosureTests_Fake.py
+++ b/ClosureTests/test/crab_ClosureTests_Fake.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+from CRABClient.UserUtilities import config
+import os
+config = config()
+
+config.General.requestName = ''
+config.General.workArea = 'crab'
+config.General.transferOutputs = True
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'config_2022_cfg.py'
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxMemoryMB = 3500
+
+config.Data.inputDataset = ''
+# config.Data.inputDBS = 'phys03'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 1
+config.Data.publication = False
+
+config.Data.outLFNDirBase = '/store/user/borzari/'
+config.Site.storageSite = 'T2_BR_SPRACE'
+config.Site.blacklist = ['T2_ES_CIEMAT']
+
+# debug = True
+debug = False
+
+if __name__ == '__main__':
+
+    from CRABAPI.RawCommand import crabCommand
+    from CRABClient.ClientExceptions import ClientException
+    from http.client import HTTPException
+    from multiprocessing import Process
+
+    def submit(config):
+        try:
+            crabCommand('submit', config = config)
+        except HTTPException as hte:
+            print("Failed submitting task: %s" % (hte.headers))
+        except ClientException as cle:
+            print("Failed submitting task: %s" % (cle))
+
+    def forkAndSubmit(config):
+        p = Process(target=submit, args=(config,))
+        p.start()
+        p.join()
+
+    # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
+
+    # valid_datasets = ['DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE']
+
+    # valid_datasets = ['WToLNu_4Jets_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE']
+
+    # valid_datasets = ['WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE']
+
+    # valid_datasets = ['Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
+
+    # valid_datasets = ['QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE']
+
+    # valid_datasets = ['DYJetsToLL_M50_2022','DYto2L_4jets_M10to50_2022','WToLNu_4Jets_2022','TbarBtoLminusNuB_2022','TBbartoLplusNuBbar_2022','TbarQtoLNu_2022','TQbartoLNu_2022','TbarWplusto2L2Nu_2022','TbarWplustoLNu2Q_2022','TWminusto2L2Nu_2022','TWminustoLNu2Q_2022','WW_2022','WZ_2022','ZZ_2022','TTto2L2Nu_2022','TTtoLNu2Q_2022','TTto4Q_2022']
+
+    # valid_datasets = ['Zto2Nu_4Jets_HT100to200_2022','Zto2Nu_4Jets_HT200to400_2022','Zto2Nu_4Jets_HT400to800_2022','Zto2Nu_4Jets_HT800to1500_2022','Zto2Nu_4Jets_HT1500to2500_2022','Zto2Nu_4Jets_HT2500_2022','QCD_PT15to30_2022','QCD_PT30to50_2022','QCD_PT50to80_2022','QCD_PT80to120_2022','QCD_PT120to170_2022','QCD_PT170to300_2022','QCD_PT300to470_2022','QCD_PT470to600_2022','QCD_PT600to800_2022','QCD_PT800to1000_2022','QCD_PT1000to1400_2022','QCD_PT1400to1800_2022','QCD_PT1800to2400_2022','QCD_PT2400to3200_2022','QCD_PT3200_2022']
+
+    # valid_datasets = ['TQbartoLNu_2022']
+
+    # valid_datasets = ['DYJetsToLL_M50_2023','DYto2L_4jets_M10to50_2023','WToLNu_4Jets_2023','TbarBtoLminusNuB_2023','TBbartoLplusNuBbar_2023','TbarQtoLNu_2023','TQbartoLNu_2023','TbarWplusto2L2Nu_2023','TbarWplustoLNu2Q_2023','TWminusto2L2Nu_2023','TWminustoLNu2Q_2023','WW_2023','WZ_2023','ZZ_2023']
+
+    valid_datasets = ['TTto2L2Nu_2023','TTtoLNu2Q_2023','TTto4Q_2023','Zto2Nu_4Jets_HT100to200_2023','Zto2Nu_4Jets_HT200to400_2023','Zto2Nu_4Jets_HT400to800_2023','Zto2Nu_4Jets_HT800to1500_2023','Zto2Nu_4Jets_HT1500to2500_2023','Zto2Nu_4Jets_HT2500_2023']
+
+    # valid_datasets = ['QCD_PT15to30_2023','QCD_PT30to50_2023','QCD_PT50to80_2023','QCD_PT80to120_2023','QCD_PT120to170_2023','QCD_PT170to300_2023','QCD_PT300to470_2023','QCD_PT470to600_2023','QCD_PT600to800_2023','QCD_PT800to1000_2023','QCD_PT1000to1400_2023','QCD_PT1400to1800_2023','QCD_PT1800to2400_2023','QCD_PT2400to3200_2023','QCD_PT3200_2023']
+
+    from DisappTrks.StandardAnalysis.miniAOD_124X_Samples import dataset_names_bkgd_MiniAOD
+
+    for dataset in dataset_names_bkgd_MiniAOD:
+        if dataset in valid_datasets:
+            config.Data.outputDatasetTag = dataset + '_ClosureTests_Fake'
+            config.General.requestName = dataset + '_ClosureTests_Fake'
+            config.Data.inputDataset = dataset_names_bkgd_MiniAOD[dataset]
+            if not debug: forkAndSubmit(config)
+            else:
+                print(config.Data.outputDatasetTag)
+                print(config.General.requestName)
+                print(config.Data.inputDataset)

--- a/ClosureTests/test/crab_ClosureTests_Fake.py
+++ b/ClosureTests/test/crab_ClosureTests_Fake.py
@@ -48,6 +48,11 @@ if __name__ == '__main__':
         p.start()
         p.join()
 
+    # valid_datasets contain the keys of the dictionary that defines the MiniAOD datasets in DisappTrks.StandardAnalysis.miniAOD_124X_Samples.
+    # Every dataset that is inside valid_datasets will be used to create a CRAB task. The only needed changes are in config.Data.inputDataset,
+    # config.Data.outputDatasetTag and config.General.requestName to assign different names to each task. The way they are separated is because
+    # Not more than ~10k jobs can be submitted at once to T2_BR_SPRACE. Not sure what is the case for the OSU T3.
+
     # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
 
     # valid_datasets = ['DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE']
@@ -68,7 +73,7 @@ if __name__ == '__main__':
 
     # valid_datasets = ['DYJetsToLL_M50_2023','DYto2L_4jets_M10to50_2023','WToLNu_4Jets_2023','TbarBtoLminusNuB_2023','TBbartoLplusNuBbar_2023','TbarQtoLNu_2023','TQbartoLNu_2023','TbarWplusto2L2Nu_2023','TbarWplustoLNu2Q_2023','TWminusto2L2Nu_2023','TWminustoLNu2Q_2023','WW_2023','WZ_2023','ZZ_2023']
 
-    valid_datasets = ['TTto2L2Nu_2023','TTtoLNu2Q_2023','TTto4Q_2023','Zto2Nu_4Jets_HT100to200_2023','Zto2Nu_4Jets_HT200to400_2023','Zto2Nu_4Jets_HT400to800_2023','Zto2Nu_4Jets_HT800to1500_2023','Zto2Nu_4Jets_HT1500to2500_2023','Zto2Nu_4Jets_HT2500_2023']
+    # valid_datasets = ['TTto2L2Nu_2023','TTtoLNu2Q_2023','TTto4Q_2023','Zto2Nu_4Jets_HT100to200_2023','Zto2Nu_4Jets_HT200to400_2023','Zto2Nu_4Jets_HT400to800_2023','Zto2Nu_4Jets_HT800to1500_2023','Zto2Nu_4Jets_HT1500to2500_2023','Zto2Nu_4Jets_HT2500_2023']
 
     # valid_datasets = ['QCD_PT15to30_2023','QCD_PT30to50_2023','QCD_PT50to80_2023','QCD_PT80to120_2023','QCD_PT120to170_2023','QCD_PT170to300_2023','QCD_PT300to470_2023','QCD_PT470to600_2023','QCD_PT600to800_2023','QCD_PT800to1000_2023','QCD_PT1000to1400_2023','QCD_PT1400to1800_2023','QCD_PT1800to2400_2023','QCD_PT2400to3200_2023','QCD_PT3200_2023']
 

--- a/ClosureTests/test/crab_ClosureTests_Lep.py
+++ b/ClosureTests/test/crab_ClosureTests_Lep.py
@@ -21,9 +21,11 @@ config.Data.splitting = 'FileBased'
 config.Data.unitsPerJob = 1
 config.Data.publication = False
 
+# This has to be changed depending on what is running: 'DY' for Pveto and 'ttbar' for the rest
 # process = 'DY'
 process = 'ttbar'
 
+# This has to be changed with the channel name from the config.py file to differentiate between tasks
 channel = 'TauTagPt55NoJetCuts'
 
 if process == 'DY':

--- a/ClosureTests/test/crab_ClosureTests_Lep.py
+++ b/ClosureTests/test/crab_ClosureTests_Lep.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+from CRABClient.UserUtilities import config
+import os
+config = config()
+
+config.General.requestName = ''
+config.General.workArea = 'crab'
+config.General.transferOutputs = True
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'config_2022_cfg.py'
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxMemoryMB = 4000
+
+config.Data.inputDataset = ''
+# config.Data.inputDBS = 'phys03'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 1
+config.Data.publication = False
+
+# process = 'DY'
+process = 'ttbar'
+
+channel = 'TauTagPt55NoJetCuts'
+
+if process == 'DY':
+
+    # dataset = '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-forPOG_130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM'
+    # datasetName = 'DYJetsToLL_M50_2022EE'
+
+    # dataset = '/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22MiniAODv4-forPOG_130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM'
+    # datasetName = 'DYJetsToLL_M50_2022'
+
+    dataset = '/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v1/MINIAODSIM'
+    datasetName = 'DYJetsToLL_M50_2023'
+
+if process == 'ttbar':
+
+    # dataset = '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM'
+    # datasetName = 'TTtoLNu2Q_2022EE'
+
+    # dataset = '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM'
+    # datasetName = 'TTtoLNu2Q_2022'
+
+    dataset = '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM'
+    datasetName = 'TTtoLNu2Q_2023'
+
+config.Data.outputDatasetTag = datasetName + '_ClosureTests_' + channel
+config.General.requestName = datasetName + '_ClosureTests_' + channel
+config.Data.inputDataset = dataset
+
+config.Data.outLFNDirBase = '/store/user/borzari/'
+config.Site.storageSite = 'T2_BR_SPRACE'
+config.Site.blacklist = ['T2_ES_CIEMAT']
+

--- a/SignalSystematics/test/crab_BGMCPlots.py
+++ b/SignalSystematics/test/crab_BGMCPlots.py
@@ -44,6 +44,12 @@ if __name__ == '__main__':
         p.start()
         p.join()
 
+    # valid_datasets contain the keys of the dictionary that defines the MiniAOD datasets in DisappTrks.StandardAnalysis.miniAOD_124X_Samples.
+    # Every dataset that is inside valid_datasets will be used to create a CRAB task. The only needed changes are in config.Data.inputDataset,
+    # config.Data.outputDatasetTag and config.General.requestName to assign different names to each task. The way they are separated is because
+    # Not more than ~10k jobs can be submitted at once to T2_BR_SPRACE. Not sure what is the case for the OSU T3.
+    # A similar procedure is done for collected data datasets, but the dictionary containing the dataset paths on DAS is set here as data_datasets.
+
     # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
 
     # valid_datasets = ['DYJetsToLL_M50_2023','DYto2L_4jets_M10to50_2023','TbarBtoLminusNuB_2023','TBbartoLplusNuBbar_2023','TbarQtoLNu_2023','TQbartoLNu_2023','TbarWplusto2L2Nu_2023','TbarWplustoLNu2Q_2023','TWminusto2L2Nu_2023','TWminustoLNu2Q_2023','WW_2023','WZ_2023','ZZ_2023']

--- a/SignalSystematics/test/crab_BGMCPlots.py
+++ b/SignalSystematics/test/crab_BGMCPlots.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+from CRABClient.UserUtilities import config
+import os
+config = config()
+
+config.General.requestName = ''
+config.General.workArea = 'crab'
+config.General.transferOutputs = True
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'config_2022_cfg.py'
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxMemoryMB = 4000
+
+config.Data.inputDataset = ''
+# config.Data.inputDBS = 'phys03'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 1
+config.Data.publication = False
+
+config.Data.outLFNDirBase = '/store/user/borzari/'
+config.Site.storageSite = 'T2_BR_SPRACE'
+
+if __name__ == '__main__':
+
+    from CRABAPI.RawCommand import crabCommand
+    from CRABClient.ClientExceptions import ClientException
+    from http.client import HTTPException
+    from multiprocessing import Process
+
+    def submit(config):
+        try:
+            crabCommand('submit', config = config)
+        except HTTPException as hte:
+            print("Failed submitting task: %s" % (hte.headers))
+        except ClientException as cle:
+            print("Failed submitting task: %s" % (cle))
+
+    def forkAndSubmit(config):
+        p = Process(target=submit, args=(config,))
+        p.start()
+        p.join()
+
+    # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
+
+    # valid_datasets = ['DYJetsToLL_M50_2023','DYto2L_4jets_M10to50_2023','TbarBtoLminusNuB_2023','TBbartoLplusNuBbar_2023','TbarQtoLNu_2023','TQbartoLNu_2023','TbarWplusto2L2Nu_2023','TbarWplustoLNu2Q_2023','TWminusto2L2Nu_2023','TWminustoLNu2Q_2023','WW_2023','WZ_2023','ZZ_2023']
+
+    # valid_datasets = ['WToLNu_4Jets_2023']
+
+    # valid_datasets = ['TTto2L2Nu_2023','TTtoLNu2Q_2023','TTto4Q_2023']
+
+    # valid_datasets = ['Zto2Nu_4Jets_HT100to200_2023','Zto2Nu_4Jets_HT200to400_2023','Zto2Nu_4Jets_HT400to800_2023','Zto2Nu_4Jets_HT800to1500_2023','Zto2Nu_4Jets_HT1500to2500_2023','Zto2Nu_4Jets_HT2500_2023','QCD_PT15to30_2023','QCD_PT30to50_2023','QCD_PT50to80_2023','QCD_PT80to120_2023','QCD_PT120to170_2023','QCD_PT170to300_2023','QCD_PT300to470_2023','QCD_PT470to600_2023','QCD_PT600to800_2023','QCD_PT800to1000_2023','QCD_PT1000to1400_2023','QCD_PT1400to1800_2023','QCD_PT1800to2400_2023','QCD_PT2400to3200_2023','QCD_PT3200_2023']
+
+    data_datasets = {
+
+        'Muon0Cv1' : '/Muon0/Run2023C-22Sep2023_v1-v1/MINIAOD',
+        'Muon0Cv2' : '/Muon0/Run2023C-22Sep2023_v2-v1/MINIAOD',
+        'Muon0Cv3' : '/Muon0/Run2023C-22Sep2023_v3-v1/MINIAOD',
+        'Muon0Cv4' : '/Muon0/Run2023C-22Sep2023_v4-v1/MINIAOD',
+        'Muon1Cv1' : '/Muon1/Run2023C-22Sep2023_v1-v1/MINIAOD',
+        'Muon1Cv2' : '/Muon1/Run2023C-22Sep2023_v2-v1/MINIAOD',
+        'Muon1Cv3' : '/Muon1/Run2023C-22Sep2023_v3-v1/MINIAOD',
+        'Muon1Cv4' : '/Muon1/Run2023C-22Sep2023_v4-v2/MINIAOD',
+
+    }
+
+    from DisappTrks.StandardAnalysis.miniAOD_124X_Samples import dataset_names_bkgd_MiniAOD
+
+    # for dataset in dataset_names_bkgd_MiniAOD:
+    #     if dataset in valid_datasets:
+    #         # config.Data.outputDatasetTag = dataset + '_basicPlotsv2'
+    #         # config.General.requestName = dataset + '_basicPlotsv2'
+    #         config.Data.outputDatasetTag = dataset + '_ZToMuMuISR'
+    #         config.General.requestName = dataset + '_ZToMuMuISR'
+    #         config.Data.inputDataset = dataset_names_bkgd_MiniAOD[dataset]
+    #         forkAndSubmit(config)
+    for dataset in data_datasets:
+        config.Data.outputDatasetTag = dataset + '_ZToMuMuISR'
+        config.General.requestName = dataset + '_ZToMuMuISR'
+        config.Data.inputDataset = data_datasets[dataset]
+        forkAndSubmit(config)

--- a/SignalSystematics/test/crab_SignalYield.py
+++ b/SignalSystematics/test/crab_SignalYield.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     #############################################################################################
 
     # These need to be set True for the blocks below to work
-    reallySubmitEWK = True
+    reallySubmitEWK = False
     reallySubmitHiggsinoEWK = False
 
     reallySubmitMass = { x : True for x in range(100, 2100, 100)}

--- a/StandardAnalysis/python/Cuts.py
+++ b/StandardAnalysis/python/Cuts.py
@@ -1553,6 +1553,10 @@ cutTrkIsoTight = cms.PSet(
     cutString = cms.string(" ( trackIsoNoPUDRp3 / pt ) < 0.01"),
     numberRequired = cms.string(">= 1"),
 )
+if not UseCandidateTracks:
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
+        # This cut does something very similar to the old trackIsoNoPUDRp3. pfIsolationDR03_.chargedHadronIso sums the pT of all PF charged pions that are compatible to the PV in a DR 0.3 cone around an IsolatedTrack. The 0.01 requirement is the same as the one used above for a tighter isolation cut.
+        cutTrkIsoTight.cutString = cms.string (" (pfIsolationDR03_.chargedHadronIso / pt) < 0.01")
 cutLeadTrkMatchHLTTrack = cms.PSet(
     inputCollection = cms.vstring("eventvariables"),
     cutString = cms.string("leadTrackMatchToHLTTrack > 0"),

--- a/StandardAnalysis/python/EventSelections.py
+++ b/StandardAnalysis/python/EventSelections.py
@@ -148,6 +148,8 @@ isoTrkSelection = copy.deepcopy(basicSelection)
 isoTrkSelection.name = cms.string("IsoTrkSelection")
 addCuts(isoTrkSelection.cuts, isoTrkWithPt55Cuts)
 
+createHitsVariations (isoTrkSelection, "isoTrkSelection")
+
 isoTrkSelectionInvertDRJetCut = copy.deepcopy (isoTrkSelection)
 isoTrkSelectionInvertDRJetCut.name = cms.string ("IsoTrkSelectionInvertDRJetCut")
 removeCuts (isoTrkSelectionInvertDRJetCut.cuts, [cutTrkJetDeltaPhi])

--- a/StandardAnalysis/python/miniAOD_124X_Samples.py
+++ b/StandardAnalysis/python/miniAOD_124X_Samples.py
@@ -250,6 +250,53 @@ dataset_names_bkgd_MiniAOD = {
     'QCD_PT2400to3200_2022' : '/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
     'QCD_PT3200_2022' : '/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM',
 
+
+
+    'DYto2L_4jets_M10to50_2023' : '/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v3/MINIAODSIM',
+    'DYJetsToLL_M50_2023' : '/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v1/MINIAODSIM',
+
+    'TbarBtoLminusNuB_2023' : '/TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM',
+    'TBbartoLplusNuBbar_2023' : '/TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM',
+    'TbarQtoLNu_2023' : '/TbarQtoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM',
+    'TQbartoLNu_2023' : '/TQbartoLNu-t-channel_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM',
+    'TbarWplusto2L2Nu_2023' : '/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v4/MINIAODSIM',
+    'TbarWplustoLNu2Q_2023' : '/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v6/MINIAODSIM',
+    'TWminusto2L2Nu_2023' : '/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'TWminustoLNu2Q_2023' : '/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+
+    'TTto2L2Nu_2023' : '/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'TTtoLNu2Q_2023' : '/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'TTto4Q_2023' : '/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+
+    'WW_2023' : '/WW_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'WZ_2023' : '/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'ZZ_2023' : '/ZZ_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+
+    'WToLNu_4Jets_2023' : '/WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v3/MINIAODSIM',
+
+    'Zto2Nu_4Jets_HT100to200_2023' : '/Zto2Nu-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT200to400_2023' : '/Zto2Nu-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT400to800_2023' : '/Zto2Nu-4Jets_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT800to1500_2023' : '/Zto2Nu-4Jets_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT1500to2500_2023' : '/Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'Zto2Nu_4Jets_HT2500_2023' : '/Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v3/MINIAODSIM',
+
+    'QCD_PT15to30_2023' : '/QCD_PT-15to30_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT30to50_2023' : '/QCD_PT-30to50_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT50to80_2023' : '/QCD_PT-50to80_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT80to120_2023' : '/QCD_PT-80to120_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT120to170_2023' : '/QCD_PT-120to170_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT170to300_2023' : '/QCD_PT-170to300_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT300to470_2023' : '/QCD_PT-300to470_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT470to600_2023' : '/QCD_PT-470to600_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT600to800_2023' : '/QCD_PT-600to800_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT800to1000_2023' : '/QCD_PT-800to1000_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT1000to1400_2023' : '/QCD_PT-1000to1400_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT1400to1800_2023' : '/QCD_PT-1400to1800_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT1800to2400_2023' : '/QCD_PT-1800to2400_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT2400to3200_2023' : '/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+    'QCD_PT3200_2023' : '/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM',
+
 }
 
 dataset_names = {}

--- a/StandardAnalysis/test/crab_BGMCPlots.py
+++ b/StandardAnalysis/test/crab_BGMCPlots.py
@@ -44,6 +44,11 @@ if __name__ == '__main__':
         p.start()
         p.join()
 
+    # valid_datasets contain the keys of the dictionary that defines the MiniAOD datasets in DisappTrks.StandardAnalysis.miniAOD_124X_Samples.
+    # Every dataset that is inside valid_datasets will be used to create a CRAB task. The only needed changes are in config.Data.inputDataset,
+    # config.Data.outputDatasetTag and config.General.requestName to assign different names to each task. The way they are separated is because
+    # Not more than ~10k jobs can be submitted at once to T2_BR_SPRACE. Not sure what is the case for the OSU T3.
+
     # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
 
     # valid_datasets = ['DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE']
@@ -52,7 +57,7 @@ if __name__ == '__main__':
 
     # valid_datasets = ['TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE']
 
-    valid_datasets = ['WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE']
+    # valid_datasets = ['WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE']
 
     # valid_datasets = ['Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
 

--- a/StandardAnalysis/test/crab_BGMCPlots.py
+++ b/StandardAnalysis/test/crab_BGMCPlots.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+from CRABClient.UserUtilities import config
+import os
+config = config()
+
+config.General.requestName = ''
+config.General.workArea = 'crab'
+config.General.transferOutputs = True
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'config_2022_cfg.py'
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxMemoryMB = 4000
+
+config.Data.inputDataset = ''
+# config.Data.inputDBS = 'phys03'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 1
+config.Data.publication = False
+
+config.Data.outLFNDirBase = '/store/user/borzari/'
+config.Site.storageSite = 'T2_BR_SPRACE'
+
+if __name__ == '__main__':
+
+    from CRABAPI.RawCommand import crabCommand
+    from CRABClient.ClientExceptions import ClientException
+    from http.client import HTTPException
+    from multiprocessing import Process
+
+    def submit(config):
+        try:
+            crabCommand('submit', config = config)
+        except HTTPException as hte:
+            print("Failed submitting task: %s" % (hte.headers))
+        except ClientException as cle:
+            print("Failed submitting task: %s" % (cle))
+
+    def forkAndSubmit(config):
+        p = Process(target=submit, args=(config,))
+        p.start()
+        p.join()
+
+    # valid_datasets = ['WToLNu_4Jets_2022EE','DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE','TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE','WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE','QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE','Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
+
+    # valid_datasets = ['DYJetsToLL_M50_2022EE','DYto2L_4jets_M10to50_2022EE']
+
+    # valid_datasets = ['WToLNu_4Jets_2022EE']
+
+    # valid_datasets = ['TbarBtoLminusNuB_2022EE','TBbartoLplusNuBbar_2022EE','TbarQtoLNu_2022EE','TQbartoLNu_2022EE','TbarWplusto2L2Nu_2022EE','TbarWplustoLNu2Q_2022EE','TWminusto2L2Nu_2022EE','TWminustoLNu2Q_2022EE']
+
+    valid_datasets = ['WW_2022EE','WZ_2022EE','ZZ_2022EE','TTto2L2Nu_2022EE','TTtoLNu2Q_2022EE','TTto4Q_2022EE']
+
+    # valid_datasets = ['Zto2Nu_4Jets_HT100to200_2022EE','Zto2Nu_4Jets_HT200to400_2022EE','Zto2Nu_4Jets_HT400to800_2022EE','Zto2Nu_4Jets_HT800to1500_2022EE','Zto2Nu_4Jets_HT1500to2500_2022EE','Zto2Nu_4Jets_HT2500_2022EE']
+
+    # valid_datasets = ['QCD_PT15to30_2022EE','QCD_PT30to50_2022EE','QCD_PT50to80_2022EE','QCD_PT80to120_2022EE','QCD_PT120to170_2022EE','QCD_PT170to300_2022EE','QCD_PT300to470_2022EE','QCD_PT470to600_2022EE','QCD_PT600to800_2022EE','QCD_PT800to1000_2022EE','QCD_PT1000to1400_2022EE','QCD_PT1400to1800_2022EE','QCD_PT1800to2400_2022EE','QCD_PT2400to3200_2022EE','QCD_PT3200_2022EE']
+
+    from DisappTrks.StandardAnalysis.miniAOD_124X_Samples import dataset_names_bkgd_MiniAOD
+
+    for dataset in dataset_names_bkgd_MiniAOD:
+        if dataset in valid_datasets:
+            # config.Data.outputDatasetTag = dataset + '_basicPlotsv2'
+            # config.General.requestName = dataset + '_basicPlotsv2'
+            config.Data.outputDatasetTag = dataset + '_distrkPlotsv2'
+            config.General.requestName = dataset + '_distrkPlotsv2'
+            config.Data.inputDataset = dataset_names_bkgd_MiniAOD[dataset]
+            forkAndSubmit(config)

--- a/TriggerAnalysis/python/TriggerAnalysisSelections.py
+++ b/TriggerAnalysis/python/TriggerAnalysisSelections.py
@@ -155,7 +155,8 @@ GrandOrDenominatorTrk = cms.PSet(
         cutLeadJetCentral,
         cutTrkPt55,
         cutTrkEta25,
-        cutTrkNormalizedChi2,
+        # cutTrkNormalizedChi2, # Replaced by high purity cut, since it doesn't exist in IsolatedTracks
+        cutTrkIsHighPurity,
         cutTrkD0,
         cutTrkDZ,
         cutTrkNValidPixelHitsSignal,

--- a/TriggerAnalysis/test/crab_SignalYield.py
+++ b/TriggerAnalysis/test/crab_SignalYield.py
@@ -63,14 +63,13 @@ if __name__ == '__main__':
             # for ctau in [10000]: # for testing; 10cm is good to check if the lifetime reweighting works from 0.1cm up to 9cm
                 # config.Data.outputDatasetTag = 'sigCentralLooseNoMissOut_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
                 # config.General.requestName = 'sigCentralLooseNoMissOut_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
-                config.Data.outputDatasetTag = 'sigJecJerNoMet_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
-                config.General.requestName = 'sigJecJerNoMet_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
+                # config.Data.outputDatasetTag = 'sigJecJerNoMet_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
+                # config.General.requestName = 'sigJecJerNoMet_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
+                config.Data.outputDatasetTag = 'sigTrigTurnOn_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
+                config.General.requestName = 'sigTrigTurnOn_AMSB_Wino%dGeV_ctau%dcm_2022EE' % (mass, ctau)
                 config.Data.inputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM' % (mass, ctau)
-                # config.Data.secondaryInputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEDRPremix-124X_mcRun3_2022_realistic_postEE_v1-v2/AODSIM' % (mass, ctau)
                 if mass == 100 and ctau == 10: # AMSB_Wino_100GeV_10cm original dataset only has 10k events; ext was created to fix it and has ~50k events
                     config.Data.inputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM' % (mass, ctau)
-                    # config.Data.secondaryInputDataset = '/AMSB_Wino_M%dGeV_ctau%dcm_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEDRPremix-124X_mcRun3_2022_realistic_postEE_v1_ext1-v2/AODSIM' % (mass, ctau)
-                config.JobType.pyCfgParams=["doLifetimeReweighting=True","massForLifetimeReweighting="+str(mass),"lifetimeForLifetimeReweighting="+str(ctau)]
                 if reallySubmitMass[mass] and reallySubmitLifetime[ctau]:
                     forkAndSubmit(config)
                 else:

--- a/TriggerAnalysis/test/crab_SignalYield.py
+++ b/TriggerAnalysis/test/crab_SignalYield.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     #############################################################################################
 
     # These need to be set True for the blocks below to work
-    reallySubmitEWK = True
+    reallySubmitEWK = False
     reallySubmitHiggsinoEWK = False
 
     reallySubmitMass = { x : True for x in range(100, 2100, 100)}


### PR DESCRIPTION
This PR updates the CRAB config files with additions to create many tasks for distinct datasets at once. It also adds the CRAB configs for the closure tests, production of many plots for the AN and signal yield and systematic studies.

It also includes in `StandardAnalysis/python/miniAOD_124X_Samples.py` the MiniAOD dataset names for 2023 BG samples.

Finally, it updated the trigger selection for systematic studies with Run 3 selections.