### PR TITLE
Fixing signal systematics to include 1cm from 10cm samples

### DIFF
--- a/SignalSystematics/python/signalSystematics.py
+++ b/SignalSystematics/python/signalSystematics.py
@@ -23,15 +23,15 @@ setTDRStyle()
 gROOT.SetBatch()
 gStyle.SetOptStat(0)
 
-def getExtraSamples(suffix, isHiggsino = False):
+def getExtraSamples(suffix, isHiggsino = False, lifetimes = []):
     masses = list(range(100, 1000, 100))
     if not isHiggsino and (suffix == '94X' or suffix == '102X'):
         masses.extend([1000, 1100])
-    if not isHiggsino and suffix == '130X):
+    if not isHiggsino and suffix == '130X':
         masses.extend([1000, 1100, 1200])
-    if isHiggsino and suffix == '130X):
+    if isHiggsino and suffix == '130X':
         masses.extend([1000])
-    ctaus = [1, 10, 100, 1000, 10000]
+    ctaus = lifetimes
     sampleName = 'Higgsino_{0}GeV_{1}cm_' if isHiggsino else 'AMSB_chargino_{0}GeV_{1}cm_'
     extraSamples = { sampleName.format(mass, ctau) + suffix : [] for mass in masses for ctau in ctaus }
 
@@ -49,11 +49,23 @@ def getExtraSamples(suffix, isHiggsino = False):
             if int (ctau) * 10 == int (ctau * 10):
                 ctau = ctauP = str (int (ctau))
             else:
-                ctau = ctauP = str (ctau)
+                ctau = ctauP = '%.1f' % ctau
                 ctauP = re.sub (r'\.', r'p', ctau)
             dataset = ('Higgsino_' if isHiggsino else 'AMSB_chargino_') + mass + 'GeV_' + ctauP + 'cm_' + suffix
 
             extraSamples[re.sub(r'_1cm_', '_10cm_', sample)].append (dataset)
+
+        if '1' not in ctaus and '10cm' in sample:
+            for i in range (2, 11):
+                ctau = ctauP = 0.01 * i * ctau0
+                if int (ctau) * 10 == int (ctau * 10):
+                    ctau = ctauP = str (int (ctau))
+                else:
+                    ctau = ctauP = '%.1f' % ctau
+                    ctauP = re.sub (r'\.', r'p', ctau)
+                dataset = ('Higgsino_' if isHiggsino else 'AMSB_chargino_') + mass + 'GeV_' + ctauP + 'cm_' + suffix
+
+                extraSamples[re.sub(r'_1cm_', '_10cm_', sample)].append (dataset)
 
     return extraSamples
 

--- a/SignalSystematics/test/signalSystematics_2022.py
+++ b/SignalSystematics/test/signalSystematics_2022.py
@@ -25,7 +25,7 @@ allLifetimes = ['0p2', '0p3', '0p4', '0p5', '0p6', '0p7', '0p8', '0p9', '1',
             #    '2', '3', '4', '5', '6', '7', '8', '9', '10']
 suffix = "130X"
 
-extraSamples = getExtraSamples(suffix)
+extraSamples = getExtraSamples(suffix, False, lifetimes)
 
 systematic = "all"
 if len (sys.argv) > 1:


### PR DESCRIPTION
This PR fixes the signal systematic script to correctly include the systematics of the 1cm samples reweighted from the 10cm samples in the `.txt` file. Already tested for the sources that are working and included them in the spreadsheet "Systematic uncertainties" in https://docs.google.com/spreadsheets/d/19JS0zfIoQxH8sVOvsY1mg-Ct1Aw80Fm0TCgxewafGp8/edit?gid=1792802112#gid=1792802112 (essentially no change was expected because of the average with all masses/lifetimes)