### PR TITLE
Remove obsolete cut removals for specific CMSSW versions

### DIFF
--- a/BackgroundEstimation/python/MuonTagProbeSelections.py
+++ b/BackgroundEstimation/python/MuonTagProbeSelections.py
@@ -190,8 +190,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
     removeCuts(MuonFiducialCalcBefore.cuts, [cutTrk2017LowEfficiencyRegion])
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     removeCuts(MuonFiducialCalcBefore.cuts, [cutTrk2018LowEfficiencyRegion])
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
-    removeCuts(MuonFiducialCalcBefore.cuts, [cutTrkEcalo, cutMuonMatchToTrigObj, cutTrkIso]) #FIXME: Make sure this removal is okay
+
 
 
 MuonFiducialCalcBeforeInvestigate2017Ineff = copy.deepcopy(MuonFiducialCalcBefore)
@@ -212,8 +211,6 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
     removeCuts(MuonFiducialCalcAfter.cuts, [cutTrk2017LowEfficiencyRegion])
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     removeCuts(MuonFiducialCalcAfter.cuts, [cutTrk2018LowEfficiencyRegion])
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
-    removeCuts(MuonFiducialCalcAfter.cuts, [cutTrkEcalo, cutMuonMatchToTrigObj, cutTrkIso])  #FIXME: Make sure this removal is okay
 
 MuonFiducialCalcAfterOldCuts = copy.deepcopy(MuonFiducialCalcAfter)
 MuonFiducialCalcAfterOldCuts.name = cms.string("MuonFiducialCalcAfterOldCuts")


### PR DESCRIPTION
cutTrkEcalo, cutMuonMatchToTrigObj, cutTrkIso were mistakenly removed from the muon fiducial map cutflow. This commit adds them back in to ensure that the code matches with what is stated in the analysis note. This change could prompt reprocessing of 2022 and 2023 data. A sample fiducial map from 2022 F is being produced without the offending code to determine how dire this is. 